### PR TITLE
Move Complex Logic from Import into Analysis [Supports bro-rita plugin]

### DIFF
--- a/analysis/sanitization/sanitization.go
+++ b/analysis/sanitization/sanitization.go
@@ -1,0 +1,101 @@
+package sanitization
+
+import (
+	"net/url"
+	"strings"
+
+	mgo "gopkg.in/mgo.v2"
+	"gopkg.in/mgo.v2/bson"
+
+	"github.com/ocmdev/rita/database"
+	"github.com/ocmdev/rita/parser/parsetypes"
+)
+
+//SanitizeData cleans up abnormalities in the imported data
+func SanitizeData(res *database.Resources) {
+	sanitizeHTTPData(res)
+}
+
+//sanitizeHTTPData cleans up abnormalities in the HTTP collection
+func sanitizeHTTPData(res *database.Resources) {
+	sess := res.DB.Session.Copy()
+	defer sess.Close()
+
+	http := sess.DB(res.DB.GetSelectedDB()).C(res.Config.T.Structure.HTTPTable)
+
+	var httpRec parsetypes.HTTP
+	httpIter := http.Find(nil).Iter()
+
+	bufferSize := res.Config.S.Bro.ImportBuffer
+	if bufferSize%2 == 1 {
+		bufferSize++
+	}
+
+	buffer := make([]interface{}, 0, bufferSize)
+
+	for httpIter.Next(&httpRec) {
+		updateDoc := sanitizeHTTPRecord(&httpRec)
+
+		if updateDoc == nil {
+			continue
+		}
+
+		if len(buffer) == bufferSize {
+			err := commitUpdateBuffer(buffer, http)
+			if err != nil {
+				res.Log.Error("Could not sanitize http records", err)
+				return
+			}
+			buffer = buffer[:0]
+		}
+		buffer = append(buffer, bson.M{"_id": httpRec.ID})
+		buffer = append(buffer, updateDoc)
+	}
+
+	if len(buffer) > 0 {
+		err := commitUpdateBuffer(buffer, http)
+		if err != nil {
+			res.Log.Error("Could not sanitize http records", err)
+			return
+		}
+	}
+}
+
+func sanitizeHTTPRecord(httpRec *parsetypes.HTTP) interface{} {
+	newURI := httpRec.URI
+
+	// ex: Host: 67.217.65.244 URI: 67.217.65.244:443
+	// URI -> :443 which will cause an error in the parser
+	if strings.HasPrefix(httpRec.URI, httpRec.Host) {
+		newURI = httpRec.URI[len(httpRec.Host):]
+	}
+
+	parsedURL, err := url.Parse(newURI)
+	if err != nil {
+		newURI = ""
+	}
+
+	//CASE: Host: www.google.com URI: http://www.google.com
+	if err == nil && parsedURL.IsAbs() {
+		newURI = parsedURL.RequestURI()
+	}
+
+	if newURI == httpRec.URI {
+		return nil
+	}
+
+	//nolint: vet
+	return bson.M{
+		"$set": bson.D{
+			{"uri", newURI},
+		},
+	}
+}
+
+func commitUpdateBuffer(buffer []interface{}, collection *mgo.Collection) error {
+	bulk := collection.Bulk()
+	bulk.Unordered()
+	bulk.Update(buffer...)
+	_, err := bulk.Run()
+	return err
+}

--- a/analysis/sanitization/sanitization.go
+++ b/analysis/sanitization/sanitization.go
@@ -7,8 +7,8 @@ import (
 	mgo "gopkg.in/mgo.v2"
 	"gopkg.in/mgo.v2/bson"
 
-	"github.com/ocmdev/rita/database"
-	"github.com/ocmdev/rita/parser/parsetypes"
+	"github.com/activecm/rita/database"
+	"github.com/activecm/rita/parser/parsetypes"
 )
 
 //SanitizeData cleans up abnormalities in the imported data

--- a/commands/analyze.go
+++ b/commands/analyze.go
@@ -9,6 +9,7 @@ import (
 	"github.com/activecm/rita/analysis/blacklist"
 	"github.com/activecm/rita/analysis/crossref"
 	"github.com/activecm/rita/analysis/dns"
+	"github.com/activecm/rita/analysis/sanitization"
 	"github.com/activecm/rita/analysis/scanning"
 	"github.com/activecm/rita/analysis/structure"
 	"github.com/activecm/rita/analysis/urls"
@@ -99,6 +100,9 @@ func analyze(inDb string, configFile string) error {
 		}).Info("Analyzing")
 		fmt.Println("[+] Analyzing " + td)
 		res.DB.SelectDB(td)
+
+		sanitization.SanitizeData(res)
+
 		logAnalysisFunc("Unique Connections", td, res,
 			structure.BuildUniqueConnectionsCollection,
 		)

--- a/commands/reset-analysis.go
+++ b/commands/reset-analysis.go
@@ -25,16 +25,16 @@ func init() {
 			if db == "" {
 				return cli.NewExitError("Specify a database", -1)
 			}
-			return cleanAnalysis(db, res)
+			return resetAnalysis(db, res)
 		},
 	}
 
 	bootstrapCommands(reset)
 }
 
-// cleanAnalysis cleans out all of the analysis data, leaving behind only the
+// resetAnalysis cleans out all of the analysis data, leaving behind only the
 // raw data from parsing the logs
-func cleanAnalysis(database string, res *database.Resources) error {
+func resetAnalysis(database string, res *database.Resources) error {
 	//clean database
 
 	conn := res.Config.T.Structure.ConnTable

--- a/parser/fileparser.go
+++ b/parser/fileparser.go
@@ -292,6 +292,5 @@ func parseLine(lineString string, header *fpt.BroHeader,
 			}).Error("Encountered unhandled type in log")
 		}
 	}
-	dat.Normalize()
 	return dat
 }

--- a/parser/parsetypes/conn.go
+++ b/parser/parsetypes/conn.go
@@ -65,6 +65,3 @@ func (in *Conn) TargetCollection(config *config.StructureTableCfg) string {
 func (in *Conn) Indices() []string {
 	return []string{"$hashed:id_orig_h", "$hashed:id_resp_h", "-duration", "ts", "uid"}
 }
-
-//Normalize pre processes this type of entry before it is imported by rita
-func (in *Conn) Normalize() {}

--- a/parser/parsetypes/dns.go
+++ b/parser/parsetypes/dns.go
@@ -27,7 +27,7 @@ type DNS struct {
 	// the query
 	TransID int64 `bson:"trans_id" bro:"trans_id" brotype:"count"`
 	// RTT contains the round trip time of this request / response
-	RTT float64 `bson:"RTT" bro:"rtt" brotype:"interval"`
+	RTT float64 `bson:"rtt" bro:"rtt" brotype:"interval"`
 	// Query contians the query string
 	Query string `bson:"query" bro:"query" brotype:"string"`
 	// QClass contains a the qclass of the query
@@ -70,6 +70,3 @@ func (in *DNS) TargetCollection(config *config.StructureTableCfg) string {
 func (in *DNS) Indices() []string {
 	return []string{"$hashed:id_orig_h", "$hashed:id_resp_h", "$hashed:query"}
 }
-
-//Normalize pre processes this type of entry before it is imported by rita
-func (in *DNS) Normalize() {}

--- a/parser/parsetypes/http.go
+++ b/parser/parsetypes/http.go
@@ -1,13 +1,11 @@
 package parsetypes
 
 import (
-	//	"net/url"
 
 	"github.com/activecm/rita/config"
 	"gopkg.in/mgo.v2/bson"
 )
 
-//import "strings"
 
 // HTTP provides a data structure for entries in bro's HTTP log file
 type HTTP struct {

--- a/parser/parsetypes/http.go
+++ b/parser/parsetypes/http.go
@@ -1,13 +1,13 @@
 package parsetypes
 
 import (
-	"net/url"
+	//	"net/url"
 
 	"github.com/activecm/rita/config"
 	"gopkg.in/mgo.v2/bson"
 )
 
-import "strings"
+//import "strings"
 
 // HTTP provides a data structure for entries in bro's HTTP log file
 type HTTP struct {
@@ -83,22 +83,4 @@ func (line *HTTP) TargetCollection(config *config.StructureTableCfg) string {
 //Indices gives MongoDB indices that should be used with the collection
 func (line *HTTP) Indices() []string {
 	return []string{"$hashed:id_orig_h", "$hashed:id_resp_h", "$hashed:user_agent", "uid"}
-}
-
-// Normalize fixes up absolute uri's as read by bro to be relative
-func (line *HTTP) Normalize() {
-	//uri is missing the protocol. set uri to ""
-	// ex: Host: 67.217.65.244 URI: 67.217.65.244:443
-	if strings.HasPrefix(line.URI, line.Host) {
-		line.URI = ""
-		return
-	}
-	parsedURL, err2 := url.Parse(line.URI)
-	if err2 != nil {
-		line.URI = ""
-		return
-	}
-	if parsedURL.IsAbs() {
-		line.URI = parsedURL.RequestURI()
-	}
 }

--- a/parser/parsetypes/parsetypes.go
+++ b/parser/parsetypes/parsetypes.go
@@ -6,7 +6,6 @@ import "github.com/activecm/rita/config"
 type BroData interface {
 	TargetCollection(*config.StructureTableCfg) string
 	Indices() []string
-	Normalize()
 }
 
 //NewBroDataFactory creates a new BroData based on the string


### PR DESCRIPTION
Currently, http records are preprocessed as they are imported in order to clean up request uri's which are absolute urls. This cleaning is important in order to obtain accurate results in the long urls portion of analysis. However, this cleaning relies on go specific libraries. In order to support the bro-rita plugin as a drop in replacement for rita's parser, this logic must be moved to the analysis step. This PR adds a "sanitization" step to analysis, in which offending records are found and updated.

Additionally, this PR changes DNS.RTT's mongo tag to "rtt" from "RTT". This change matches Bro's name for the field. 

With this PR, bro-rita will become a viable drop in replacement for rita's existing parser.