### PR TITLE
Extending docker capabilities and adding statically linked binary build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,8 +10,6 @@ default:
 	dep ensure
 	go build ${LDFLAGS}
 
-# Having issues with 'go install' + LDFLAGS using sudo and the
-# install script. This is a workaround.
 install:
 	dep ensure
 	go build ${LDFLAGS} -o ${GOPATH}/bin/${BINARY}

--- a/Readme.md
+++ b/Readme.md
@@ -1,6 +1,6 @@
 # RITA (Real Intelligence Threat Analytics)
 
-Brought to you by Active CounterMeasures.
+Brought to you by Active Countermeasures.
 
 ---
 ### What is Here
@@ -19,8 +19,6 @@ Additional functionality is being developed and will be included soon.
 ### Automatic Installation
 **The automatic  installer is officially supported on Ubuntu 14.04, 16.04 LTS, Security Onion, and CentOS 7**
 
-
-
 * Clone the package:
 `git clone https://github.com/activecm/rita.git`
 * Change into the source directory: `cd rita`
@@ -34,7 +32,6 @@ To install each component of RITA by hand, [check out the instructions in the wi
 RITA contains a yaml format configuration file.
 
 You can specify the location for the configuration file with the **-c** command line flag. If not specified, RITA will look for the configuration in **/etc/rita/config.yaml**.
-
 
 ### API Keys
 RITA relies on the the [Google Safe Browsing API](https://developers.google.com/safe-browsing/) to check network log data for connections to known threats. An API key is required to use this service. Obtaining a key is free, and only requires a Google account.
@@ -94,4 +91,4 @@ To contribute to RITA visit our [Contributing Guide](https://github.com/activecm
 
 ### License
 GNU GPL V3
-&copy; Active CounterMeasures &trade;
+&copy; Active Countermeasures &trade;

--- a/docs/Docker Usage.md
+++ b/docs/Docker Usage.md
@@ -1,0 +1,71 @@
+# Docker Usage
+
+You can run RITA using Docker! You have several options depending on your specific needs.
+* Running RITA with Docker Compose - This is the simplest option and requires the least setup. You will have to provide your own Bro logs.
+* Running RITA with Docker Using External Mongo - This option is useful if you do not want to use Docker Compose or you have an external Mongo server you wish to use.
+* Using Docker to Build RITA - You can use Docker to build a standalone RITA binary that runs on any Linux 64-bit CPU. This is useful if you want a portable binary but don't want to use Docker to actually run RITA.
+
+## Obtaining the RITA Docker Image
+
+The easiest way is to pull down the pre-built image.
+
+```
+docker pull activecm/rita:latest
+```
+
+You can also build the image from scratch.
+
+```
+docker build -t activecm/rita:latest .
+```
+
+## Running RITA with Docker Compose
+
+At the very least, you will have to provide RITA with the path to your Bro log files using the `BRO_LOGS` environment variable.
+
+```
+export BRO_LOGS=/path/to/your/logs
+docker-compose run --rm rita import
+docker-compose run --rm rita analyze
+```
+
+You can also call it this way if you wish.
+
+```
+BRO_LOGS=/path/to/your/logs docker-compose run --rm rita import
+BRO_LOGS=/path/to/your/logs docker-compose run --rm rita analyze
+```
+
+RITA will use the default `config.yaml` file which will work out of the box. If you wish to specify your own config file you can do so like this:
+
+```
+export BRO_LOGS=/path/to/your/logs
+docker-compose run --rm -v /path/to/your/rita/config.yaml:/etc/rita/config.yaml rita show-databases
+```
+
+## Running RITA with Docker Using External Mongo
+
+If you don't need/want the convenience of Docker Compose running the Mongo server for you, you can also use RITA without it. You will need to modify RITA's config file to point to your external Mongo server.
+
+```
+docker run -it --rm \
+	-v /path/to/your/bro/logs:/opt/bro/logs/:ro \
+	-v /path/to/your/rita/config.yaml:/etc/rita/config.yaml:ro \
+	activecm/rita:latest import
+docker run -it --rm \
+	-v /path/to/your/bro/logs:/opt/bro/logs/:ro \
+	-v /path/to/your/rita/config.yaml:/etc/rita/config.yaml:ro \
+	activecm/rita:latest analyze
+```
+
+## Using Docker to Build RITA
+
+You can use Docker to build a statically linked RITA binary for you. This binary should be portable between Linux 64-bit systems. Once you've obtained the RITA docker image (see the "Obtaining the RITA Docker Image" section above) you can run the following commands to copy the binary to your host system.
+
+```
+docker create --name rita activecm/rita:latest
+docker cp rita:/rita ./rita
+docker rm rita
+```
+
+Note that you will have to manually install the `config.yaml` and `tables.yaml` files into `/etc/rita/` as well as create any directories referenced inside the `config.yaml` file.


### PR DESCRIPTION
- Update go version for docker image
- Build out to a statically linked binary (linux 64-bit)
- Move documentation to docs folder
- s/CounterMeasures/Countermeasures