### PR TITLE
Pull a statically linked RITA binary from github

### DIFF
--- a/Contributing.md
+++ b/Contributing.md
@@ -24,6 +24,8 @@ Just be sure to do the following:
 
 ## Contributing Code
 There are several ways to contribute code to the RITA project.
+Before diving in, follow the [Manual Installation Instructions](https://github.com/activecm/rita/blob/v1.0.0/docs/Manual%20Installation.md)
+
 * Add godoc comments and fix style compliance issues:
   * Run the [go metalinter](https://github.com/alecthomas/gometalinter)
   * Find a linting error and fix it
@@ -41,57 +43,24 @@ There are several ways to contribute code to the RITA project.
   * When you're ready to test code run `go test ./...` from the root directory
   of the project
   * Feel free to refactor code to increase our ability to test it
-  * Join our [IRC](https://github.com/activecm/rita/wiki/RITA-Gittiquette) to
-  learn more
 * Add new features:
   * If you would like to become involved in the development effort, please hop
    on our [OFTC channel at #activecm](https://webchat.oftc.net/?channels=activecm)
    and chat about what is currently being worked on.
 
 All of these tasks ultimately culminate in a pull request being issued,
-reviewed, and merged. When interacting with RITA through Git please check out
-the
-[RITA Gittiquette page](https://github.com/activecm/rita/wiki/RITA-Gittiquette).
-Go limits the ways you may use Git with an open source project such as RITA, so
-it is important that you understand the procedures laid out here.
+reviewed, and merged. 
 
 ### Gittiquette Summary
-* We currently have a dev and master branch on activecm
-  * Master is our tagged release branch
-  * Dev is our development and staging branch
-  * As more users come to rely on RITA, we will introduce a release-testing branch
-  for release candidates
 * In order to contribute to RITA, you must fork it
   * Do not `go get` or `git clone` your forked repo
   * Instead, `git remote add` it to your existing RITA repository
-* Checkout the dev branch `git checkout dev`
-* Split a branch off of dev `git checkout -b [a-new-branch]`
+* Split a branch off of master `git checkout -b [a-new-branch]`
 * Push your commits to your remote if you wish to develop in the public
-* When your work is finished, pull down the latest dev branch, and rebase
+* When your work is finished, pull down the latest master branch, and rebase
 your feature branch off of it
 * Submit a pull request on Github
-
-### Switching to the `dev` Branch
-* Install RITA using either the [installer](https://raw.githubusercontent.com/activecm/rita/master/install.sh) or
-[manually](https://github.com/activecm/rita/wiki/Installation)
-* `cd $GOPATH/src/github.com/activecm/rita`
-* `git checkout dev`
-* `make install`
-* Configure a config file for the dev branch
-  * Make a backup of your config file for the master branch
-  * Copy over the config from `etc/rita.yaml` to `~/.rita/config.yaml`
-  * Update the newly copied config to match your old one
 
 ### Common Issues
 * Building Rita using `go install` or `go build` yields a RITA version of `UNDEFINED`
   * Use `make` or `make install`.
-* The dev branch is likely to break compatibility with datasets processed using
-the master branch
-  * Usually, resetting analysis will take care of the incompatible datasets
-  * If the parser has been altered, a fresh import may be needed
-  * If errors persist, manually delete the MetaDB out of MongoDB
-* The dev branch is likely to break compatibility with the default installed
-config file at `~/.rita/config.yaml`
-  * Make a backup of your config file for the master branch
-  * Copy over the config from `etc/rita.yaml` to `~/.rita/config.yaml`
-  * Update the newly copied config to match your old one

--- a/Readme.md
+++ b/Readme.md
@@ -22,7 +22,7 @@ Additional functionality is being developed and will be included soon.
 * Clone the package:
 `git clone https://github.com/activecm/rita.git`
 * Change into the source directory: `cd rita`
-* Run the installer: `./install.sh`
+* Run the installer: `sudo ./install.sh`
 * Start MongoDB: `sudo service mongod start`
 
 ### Manual Installation

--- a/Readme.md
+++ b/Readme.md
@@ -25,7 +25,7 @@ Additional functionality is being developed and will be included soon.
 * Start MongoDB: `sudo service mongod start`
 
 ### Manual Installation
-To install each component of RITA by hand, [check out the instructions in the wiki](https://github.com/activecm/rita/blob/master/docs/Manual%20Installation.md).
+To install each component of RITA by hand, [check out the instructions in the docs](https://github.com/activecm/rita/blob/master/docs/Manual%20Installation.md).
 
 ### Configuration File
 RITA contains a yaml format configuration file.
@@ -81,6 +81,7 @@ To obtain an API key:
   * `-H` displays human readable data
   * `rita show-beacons dataset_name -H`
   * `rita show-blacklisted dataset_name -H`
+  * Use less to view data `rita show-beacons dataset_name -H | less -S`
 
 ### Getting help
 Please create an issue on GitHub if you have any questions or concerns.

--- a/Readme.md
+++ b/Readme.md
@@ -8,25 +8,24 @@ Brought to you by Active Countermeasures.
 RITA is an open source framework for network traffic analysis.
 
 The framework ingests [Bro Logs](https://www.bro.org/), and currently supports the following analysis features:
- - **Beaconing**: Search for signs of beaconing behavior in and out of your network
- - **DNS Tunneling** Search for signs of DNS based covert channels
- - **Blacklisted**: Query blacklists to search for suspicious domains and hosts
+ - **Beaconing Detection**: Search for signs of beaconing behavior in and out of your network
+ - **DNS Tunneling Detection** Search for signs of DNS based covert channels
+ - **Blacklist Checking**: Query blacklists to search for suspicious domains and hosts
  - **URL Length Analysis**: Search for lengthy URLs indicative of malware
- - **Scanning**: Search for signs of port scans in your network
+ - **Scanning Detection**: Search for signs of port scans in your network
 
 Additional functionality is being developed and will be included soon.
 
 ### Automatic Installation
 **The automatic  installer is officially supported on Ubuntu 14.04, 16.04 LTS, Security Onion, and CentOS 7**
 
-* Clone the package:
-`git clone https://github.com/activecm/rita.git`
-* Change into the source directory: `cd rita`
+* Download the latest `install.sh` file from the [release page](https://github.com/activecm/rita/releases/latest)
+* Make the installer executable: `chmod +x ./install.sh`
 * Run the installer: `sudo ./install.sh`
 * Start MongoDB: `sudo service mongod start`
 
 ### Manual Installation
-To install each component of RITA by hand, [check out the instructions in the wiki](https://github.com/activecm/rita/wiki/Installation).
+To install each component of RITA by hand, [check out the instructions in the wiki](https://github.com/activecm/rita/blob/master/docs/Manual%20Installation.md).
 
 ### Configuration File
 RITA contains a yaml format configuration file.

--- a/docs/Manual Installation.md
+++ b/docs/Manual Installation.md
@@ -46,7 +46,7 @@
     1. Allow users to write to the safebrowsing file
         * ```sudo chmod 666 /var/lib/rita/safebrowsing```
     1. Install the config file
-	* ```sudo cp etc/rita.yaml /etc/rita/config.yaml```
+        * ```sudo cp etc/rita.yaml /etc/rita/config.yaml```
     1. Allow users to write to the RITA config file
         * ```sudo chmod 666 /etc/rita/config.yaml```
     1. You can test a configuration file with ```rita test-config -c PATH/TO/FILE```

--- a/docs/Manual Installation.md
+++ b/docs/Manual Installation.md
@@ -1,0 +1,55 @@
+
+### Installation
+
+1. What you'll need:
+    * Bro [https://www.bro.org](https://www.bro.org)
+    * MongoDB [https://www.mongodb.com](https://www.mongodb.com)
+    * Golang [https://www.golang.org](https://www.golang.org)
+1. Install Bro [Optional]:
+    1. Follow the directions at [https://www.bro.org/sphinx/install/install.html](https://www.bro.org/sphinx/install/install.html)
+    1. Test that bro is working by firing up bro and ensuring that it's spitting out logs. If you're having some trouble with bro configuration or use, here are some helpful links:
+        * Bro quick start [https://www.bro.org/sphinx-git/quickstart/index.html](https://www.bro.org/sphinx-git/quickstart/index.html)
+        * broctl [https://www.bro.org/sphinx/components/broctl/README.html](https://www.bro.org/sphinx/components/broctl/README.html)
+1. Install MongoDB (You will need MongoDB >= 3.2.0 which is not included by default in the Ubuntu 16.04 package manager.)
+    * Follow the MongoDB installation guide at https://docs.mongodb.com/manual/installation/
+    * Download a version >= 3.2.0 at https://www.mongodb.com/download-center?jmp=nav#community
+    * Ensure MongoDB is running before continuing  
+1. Install GoLang using the instructions at [https://golang.org/doc/install](https://golang.org/doc/install)
+    1. After the install we need to set a local GOPATH for our user. So lets set up a directory in our HomeDir
+        * ```mkdir -p $HOME/go/{src,pkg,bin}```
+    1. Now we must add the GoPath to our .bashrc file
+        * ```echo 'export GOPATH="$HOME/go"' >> $HOME/.bashrc```
+    1. We will also want to add our bin folder to the path for this user.
+        * ```echo 'export PATH="$PATH:$GOPATH/bin"' >> $HOME/.bashrc```
+    1. Load your new configurations with source.
+        * ```source $HOME/.bashrc```
+1. Getting RITA and building it
+  	1. First we want to use the go to grab sources and deps for rita.
+    	* ```go get github.com/activecm/rita```
+  	1. Now lets change to the rita directory.
+    	* ```cd $GOPATH/src/github.com/activecm/rita```
+  	1. Finally we'll build and install the rita binary.
+  		* ```make install```
+		* This will install to `$GOPATH/bin/rita` not `/usr/local/bin/rita`
+1. Configuring the system
+    1. Create a configuration directory at `/etc/rita`
+        * ```sudo mkdir /etc/rita```
+    1. Allow users to read the configuration directory
+        * ```sudo chmod 755 /etc/rita```
+    1. Create a runtime directory for rita at `/var/lib/rita`
+        * ```sudo mkdir -p /var/lib/rita/logs```
+    1. Allow users to write to the runtime directory
+        * ```sudo chmod 755 /var/lib/rita```
+        * ```sudo chmod 777 /var/lib/rita/logs```
+    1. Create the safebrowsing database file
+        * ```sudo touch /var/lib/rita/safebrowsing```
+    1. Allow users to write to the safebrowsing file
+        * ```sudo chmod 666 /var/lib/rita/safebrowsing```
+    1. Install the config file
+	* ```sudo cp etc/rita.yaml /etc/rita/config.yaml```
+    1. Allow users to write to the RITA config file
+        * ```sudo chmod 666 /etc/rita/config.yaml```
+    1. You can test a configuration file with ```rita test-config -c PATH/TO/FILE```
+        * There will be empty quotes or 0's assigned to empty fields
+    1. Follow the documentation in the Readme.md for configuring RITA
+

--- a/docs/Releases.md
+++ b/docs/Releases.md
@@ -4,7 +4,7 @@ Steps for creating a RITA release.
 
 - Tag a commit on master as a release
 	- Checkout the commit
-	- `git tag [version]`
+	- Tag the commit with `git tag [version]`
 		- Follow [SemVer](https://semver.org)
 	- Push the tag to github using `git push origin [version]`
 - Wait for Quay.io to build the docker image

--- a/docs/Releases.md
+++ b/docs/Releases.md
@@ -4,21 +4,21 @@ Steps for creating a RITA release.
 
 - Tag a commit on master as a release
 	- Checkout the commit
-	- "git tag \[version\]"
+	- `git tag [version]`
 		- Follow [SemVer](https://semver.org)
-	- Push the tag to github using "git push origin \[version\]"
+	- Push the tag to github using `git push origin [version]`
 - Wait for Quay.io to build the docker image
 - [Use docker to create the build](https://github.com/activecm/rita/blob/master/docs/Docker%20Usage.md#using-docker-to-build-rita)
-	- Instead of "rita:master", use "rita:\[version\]"
+	- Instead of `rita:master`, use `rita:[version]`
 - Go to the [releases](https://github.com/activecm/rita/releases) page
-	- Click "Draft a new release"
-	- Select the new "\[version\]" tag
+	- Click `Draft a new release`
+	- Select the new `[version]` tag
 	- Fill out the title and description with recent changes
-		- If the config.yaml file changed, give a thorough description of the needed changes
+		- If the config file changed, give a thorough description of the needed changes
 	- Attach the following files:
-		- The rita binary, pulled from the docker image
-		- The rita.yaml file for the tagged code base
-			- IMPORTANT: This must be named config.yaml in the release
-		- The LICENSE file for the tagged code base
-		- The install.sh file for the tagged code base
+		- The `rita` binary, pulled from the docker image
+		- The `rita.yaml` file for the tagged code base
+			- IMPORTANT: This must be named `config.yaml` in the release
+		- The `LICENSE` file for the tagged code base
+		- The `install.sh` file for the tagged code base
 	- Publish the release

--- a/docs/Releases.md
+++ b/docs/Releases.md
@@ -17,8 +17,5 @@ Steps for creating a RITA release.
 		- If the config file changed, give a thorough description of the needed changes
 	- Attach the following files:
 		- The `rita` binary, pulled from the docker image
-		- The `rita.yaml` file for the tagged code base
-			- IMPORTANT: This must be named `config.yaml` in the release
-		- The `LICENSE` file for the tagged code base
 		- The `install.sh` file for the tagged code base
 	- Publish the release

--- a/docs/Releases.md
+++ b/docs/Releases.md
@@ -1,0 +1,24 @@
+# Releases
+
+Steps for creating a RITA release. 
+
+- Tag a commit on master as a release
+	- Checkout the commit
+	- "git tag \[version\]"
+		- Follow [SemVer](https://semver.org)
+	- Push the tag to github using "git push origin \[version\]"
+- Wait for Quay.io to build the docker image
+- [Use docker to create the build](https://github.com/activecm/rita/blob/master/docs/Docker%20Usage.md#using-docker-to-build-rita)
+	- Instead of "rita:master", use "rita:\[version\]"
+- Go to the [releases](https://github.com/activecm/rita/releases) page
+	- Click "Draft a new release"
+	- Select the new "\[version\]" tag
+	- Fill out the title and description with recent changes
+		- If the config.yaml file changed, give a thorough description of the needed changes
+	- Attach the following files:
+		- The rita binary, pulled from the docker image
+		- The rita.yaml file for the tagged code base
+			- IMPORTANT: This must be named config.yaml in the release
+		- The LICENSE file for the tagged code base
+		- The install.sh file for the tagged code base
+	- Publish the release

--- a/install.sh
+++ b/install.sh
@@ -96,6 +96,7 @@ __entry() {
 		if [[ ! $REPLY =~ ^[Yy]$ ]]; then
 			exit 0
 		fi
+		_REINSTALL_RITA="true"
 	fi
 
 	__install

--- a/install.sh
+++ b/install.sh
@@ -187,14 +187,10 @@ __install_bro() {
 			;;
 		CentOS)
 			__add_rpm_repo http://download.opensuse.org/repositories/network:bro/CentOS_7/network:bro.repo
-			
 			# Workaround for https://github.com/activecm/rita/issues/189
-			curl -sSL http://download.opensuse.org/repositories/network%3A/bro/CentOS_7/x86_64/bro-2.5.3-1.1.x86_64.rpm -o /tmp/bro-2.5.3-1.1.x86_64.rpm
-			curl -sSL http://download.opensuse.org/repositories/network%3A/bro/CentOS_7/x86_64/bro-core-2.5.3-1.1.x86_64.rpm -o /tmp/bro-core-2.5.3-1.1.x86_64.rpm
-			curl -sSL http://download.opensuse.org/repositories/network%3A/bro/CentOS_7/x86_64/broctl-2.5.3-1.1.x86_64.rpm -o /tmp/broctl-2.5.3-1.1.x86_64.rpm
-			curl -sSL http://download.opensuse.org/repositories/network%3A/bro/CentOS_7/x86_64/libbroccoli-2.5.3-1.1.x86_64.rpm -o /tmp/libbroccoli-2.5.3-1.1.x86_64.rpm
-			yum -y -q localinstall /tmp/bro-2.5.3-1.1.x86_64.rpm /tmp/bro-core-2.5.3-1.1.x86_64.rpm /tmp/broctl-2.5.3-1.1.x86_64.rpm /tmp/libbroccoli-2.5.3-1.1.x86_64.rpm
-			# End workaround
+			# Replace the download.opensuse.org link with downloadcontent.opensuse.org link
+			# https://www.linuxquestions.org/questions/linux-general-1/yum-update-failed-because-of-timeout-4175625075/#post5828487
+			cat '/etc/yum.repos.d/network:bro.repo' | sed -e 's/download\.opensuse\.org/downloadcontent.opensuse.org/g' | tee '/etc/yum.repos.d/network:bro.repo.tmp' >/dev/null && mv -f '/etc/yum.repos.d/network:bro.repo.tmp' '/etc/yum.repos.d/network:bro.repo'
 			;;
 	esac
 	__install_packages bro broctl

--- a/install.sh
+++ b/install.sh
@@ -240,7 +240,7 @@ __install_rita() {
 	_RITA_CONFIG_URL="$_RITA_DOWNLOAD_URL/config.yaml"
 	_RITA_LICENSE_URL="$_RITA_DOWNLOAD_URL/LICENSE"
 	
-	curl -sSL $_RITA_BINARY_URL -o $_BIN_PATH/rita
+	curl -sSL "$_RITA_BINARY_URL" -o "$_BIN_PATH/rita"
 	chmod 755 "$_BIN_PATH/rita"
 
 	mkdir -p "$_CONFIG_PATH"
@@ -251,14 +251,16 @@ __install_rita() {
 	curl -sSL "$_RITA_LICENSE_URL" -o "$_CONFIG_PATH/LICENSE"
 
 	if [ -f "$_CONFIG_PATH/config.yaml" ]; then
-		printf "$_SUBITEM Backing up your current RITA config: $_CONFIG_PATH/config.yaml -> $_CONFIG_PATH/config.yaml.old \n"
-		mv -f "$_CONFIG_PATH/config.yaml" "$_CONFIG_PATH/config.yaml.old"
+		# Don't overwrite existing config
+		curl -sSL "$_RITA_CONFIG_URL" -o "$_CONFIG_PATH/config.yaml.new"
+		chmod 666 "$_CONFIG_PATH/config.yaml.new"
+  else
+		curl -sSL "$_RITA_CONFIG_URL" -o "$_CONFIG_PATH/config.yaml"
+		chmod 666 "$_CONFIG_PATH/config.yaml"
 	fi
-	curl -sSL "$_RITA_CONFIG_URL" -o "$_CONFIG_PATH/config.yaml"
 
 	# All users can read and write rita's config file
 	chmod 755 "$_CONFIG_PATH"
-	chmod 666 "$_CONFIG_PATH/config.yaml"
 
 	touch "$_VAR_PATH/safebrowsing"
 	chmod 755 "$_VAR_PATH"

--- a/install.sh
+++ b/install.sh
@@ -240,10 +240,11 @@ __install_rita() {
 		_RITA_VERSION="$(eval $_LATEST_VERSION_COMMAND)"
 	fi
 
-	_RITA_DOWNLOAD_URL="https://github.com/activecm/rita/releases/download/$_RITA_VERSION"
-	_RITA_BINARY_URL="$_RITA_DOWNLOAD_URL/rita"	
-	_RITA_CONFIG_URL="$_RITA_DOWNLOAD_URL/config.yaml"
-	_RITA_LICENSE_URL="$_RITA_DOWNLOAD_URL/LICENSE"
+	_RITA_RELEASE_URL="https://github.com/activecm/rita/releases/download/$_RITA_VERSION"
+	_RITA_REPO_URL="https://raw.githubusercontent.com/activecm/rita/$_RITA_VERSION"
+	_RITA_BINARY_URL="$_RITA_RELEASE_URL/rita"
+	_RITA_CONFIG_URL="$_RITA_REPO_URL/etc/rita.yaml"
+	_RITA_LICENSE_URL="$_RITA_REPO_URL/LICENSE"
 	
 	_RITA_CONFIG_FILE="$_CONFIG_PATH/config.yaml"
 	_RITA_REINSTALL_CONFIG_FILE="$_CONFIG_PATH/config.yaml.new"

--- a/install.sh
+++ b/install.sh
@@ -142,6 +142,11 @@ __install() {
 	fi
 
 	__load "$_ITEM Installing RITA" __install_rita
+	if [ "$_REINSTALL_RITA" = "true" ]; then
+		printf "$_IMPORTANT $_RITA_CONFIG_FILE may need to be updated for this version of RITA. \n"
+		printf "$_IMPORTANT A default config file has been created at $_RITA_REINSTALL_CONFIG_FILE. \n"
+		printf "$_IMPORTANT \"rita test-config\" may be used to troubleshoot configuration issues. \n \n"
+	fi
 
 	# Ubuntu 14.04 uses Upstart for init
         _START_MONGO="sudo systemctl start mongod"
@@ -240,6 +245,9 @@ __install_rita() {
 	_RITA_CONFIG_URL="$_RITA_DOWNLOAD_URL/config.yaml"
 	_RITA_LICENSE_URL="$_RITA_DOWNLOAD_URL/LICENSE"
 	
+	_RITA_CONFIG_FILE="$_CONFIG_PATH/config.yaml"
+	_RITA_REINSTALL_CONFIG_FILE="$_CONFIG_PATH/config.yaml.new"
+
 	curl -sSL "$_RITA_BINARY_URL" -o "$_BIN_PATH/rita"
 	chmod 755 "$_BIN_PATH/rita"
 
@@ -250,13 +258,13 @@ __install_rita() {
 
 	curl -sSL "$_RITA_LICENSE_URL" -o "$_CONFIG_PATH/LICENSE"
 
-	if [ -f "$_CONFIG_PATH/config.yaml" ]; then
+	if [ "$_REINSTALL_RITA" = "true" ]; then
 		# Don't overwrite existing config
-		curl -sSL "$_RITA_CONFIG_URL" -o "$_CONFIG_PATH/config.yaml.new"
-		chmod 666 "$_CONFIG_PATH/config.yaml.new"
-  else
-		curl -sSL "$_RITA_CONFIG_URL" -o "$_CONFIG_PATH/config.yaml"
-		chmod 666 "$_CONFIG_PATH/config.yaml"
+		curl -sSL "$_RITA_CONFIG_URL" -o "$_RITA_REINSTALL_CONFIG_FILE"
+		chmod 666 "$_RITA_REINSTALL_CONFIG_FILE"
+	else
+		curl -sSL "$_RITA_CONFIG_URL" -o "$_RITA_CONFIG_FILE"
+		chmod 666 "$_RITA_CONFIG_FILE"
 	fi
 
 	# All users can read and write rita's config file

--- a/install.sh
+++ b/install.sh
@@ -33,38 +33,9 @@ set -o errexit
 set -o errtrace
 set -o pipefail
 
-
-# PERMISSIONS GADGET
-# The user must run the build process, but root must install
-# software. In order to make sure the appropriate users
-# take the right actions, we call sudo in the script itself.
-
-# Prevent user running sudo themselves
-if [ ! -z ${SUDO_USER+x} ]; then
-	printf "Please run the RITA installer without sudo.\n"
+if ! [ $(id -u) = 0 ]; then 
+	echo "You do not have permissions to install RITA!"
 	exit 1
-fi
-
-# Root is running the script without sudo
-if [ "$EUID" = "0" ]; then
-	_ELEVATE=""
-else
-	printf "$_IMPORTANT The RITA installer requires root privileges for some tasks. \n"
-	printf "$_IMPORTANT \"sudo\" will be used when necessary. \n"
-	_SUDO="$(type -fp sudo)"
-	if [ -z $_SUDO ]; then
-		printf "\"sudo\" was not found on the system. Please log in as root \n"
-		printf "before running the installer, or install \"sudo\". \n"
-		exit 1
-	fi
-	$_SUDO -v
-	if [ $? -ne 0 ]; then
-		printf "The installer was unable to elevate privileges using \"sudo\". \n"
-		printf "Please make sure your account has \"sudo\" privileges. \n"
-	fi
-	# _ELEVATE is separate from _SUDO since environment variables may need
-	# to be passed
-	_ELEVATE="$_SUDO"
 fi
 
 # ENTRYPOINT
@@ -145,7 +116,6 @@ __install() {
 	# Get system information
 	__gather_OS
 	__gather_bro
-	__gather_go
 	__gather_mongo
 
 	# Explain the installer's actions
@@ -163,35 +133,6 @@ __install() {
 		fi
 	fi
 
-	# Always install Go
-	if [ "$_GO_OUT_OF_DATE" = "true" ]; then
-		printf "$_IMPORTANT WARNING: An old version of Go has been detected on this system. \n"
-		printf "$_IMPORTANT RITA has only been tested with Go >= 1.7. Check if the installed \n"
-		printf "$_IMPORTANT version of Go is up to date with 'go version'. If it is out of date \n"
-		printf "$_IMPORTANT you may remove the old version of Go and let this installer install \n"
-		printf "$_IMPORTANT a more recente version. \n"
-		sleep 10s
-	fi
-
-	if [ "$_GO_INSTALLED" = "false" ]; then
-		__load "$_ITEM Installing Go" __install_go
-	else
-		printf "$_ITEM Go is already installed \n"
-	fi
-
-	if [ "$_GO_IN_PATH" = "false" ]; then
-		__add_go_to_path
-	fi
-
-	if [ "$_GOPATH_EXISTS" = "false" ]; then
-		__create_go_path
-	else
-		printf "$_SUBITEM Found GOPATH at $GOPATH \n"
-		# Add the bin folder of the $GOPATH
-		# It may already be in the path, but oh well, better to be safe than sorry
-		export PATH=$PATH:$GOPATH/bin
-	fi
-
 	if [ $_INSTALL_MONGO = "true" ]; then
 		if [ $_MONGO_INSTALLED = "false" ]; then
 			__load "$_ITEM Installing MongoDB" __install_mongodb
@@ -200,7 +141,7 @@ __install() {
 		fi
 	fi
 
-	__load "$_ITEM Installing RITA" __build_rita && __install_rita
+	__load "$_ITEM Installing RITA" __install_rita
 
 	# Ubuntu 14.04 uses Upstart for init
         _START_MONGO="sudo systemctl start mongod"
@@ -210,12 +151,12 @@ __install() {
 		_STOP_MONGO="sudo service mongod stop"
 	fi
 
-	printf "$_IMPORTANT To finish the installtion, reload the system profile and \n"
-	printf "$_IMPORTANT user profile with 'source /etc/profile' and 'source ~/.profile'. \n"
-	printf "$_IMPORTANT Additionally, you may want to configure Bro and run 'sudo broctl deploy'. \n"
-	printf "$_IMPORTANT Finally, start MongoDB with '$_START_MONGO'. You can \n"
-	printf "$_IMPORTANT access the MongoDB shell with 'mongo'. If, at any time, you need \n"
-	printf "$_IMPORTANT to stop MongoDB, run '$_STOP_MONGO'. \n"
+	printf "$_IMPORTANT To finish the installation, reload the system profile with \n"
+	printf "$_IMPORTANT 'source /etc/profile'. Additionally, you may want to configure Bro \n"
+	printf "$_IMPORTANT by running 'sudo broctl deploy'. Finally, start MongoDB with \n"
+	printf "$_IMPORTANT '$_START_MONGO'. You can access the MongoDB shell with \n"
+	printf "$_IMPORTANT 'mongo'. If, at any time, you need to stop MongoDB, \n"
+	printf "$_IMPORTANT run '$_STOP_MONGO'. \n"
 
 	__title
 	printf "Thank you for installing RITA! Happy hunting! \n"
@@ -247,12 +188,12 @@ __install_bro() {
 			curl -sSL http://download.opensuse.org/repositories/network%3A/bro/CentOS_7/x86_64/bro-core-2.5.3-1.1.x86_64.rpm -o /tmp/bro-core-2.5.3-1.1.x86_64.rpm
 			curl -sSL http://download.opensuse.org/repositories/network%3A/bro/CentOS_7/x86_64/broctl-2.5.3-1.1.x86_64.rpm -o /tmp/broctl-2.5.3-1.1.x86_64.rpm
 			curl -sSL http://download.opensuse.org/repositories/network%3A/bro/CentOS_7/x86_64/libbroccoli-2.5.3-1.1.x86_64.rpm -o /tmp/libbroccoli-2.5.3-1.1.x86_64.rpm
-			$_ELEVATE yum -y -q localinstall /tmp/bro-2.5.3-1.1.x86_64.rpm /tmp/bro-core-2.5.3-1.1.x86_64.rpm /tmp/broctl-2.5.3-1.1.x86_64.rpm /tmp/libbroccoli-2.5.3-1.1.x86_64.rpm
+			yum -y -q localinstall /tmp/bro-2.5.3-1.1.x86_64.rpm /tmp/bro-core-2.5.3-1.1.x86_64.rpm /tmp/broctl-2.5.3-1.1.x86_64.rpm /tmp/libbroccoli-2.5.3-1.1.x86_64.rpm
 			# End workaround
 			;;
 	esac
 	__install_packages bro broctl
-	$_ELEVATE chmod 2755 /opt/bro/logs
+	chmod 2755 /opt/bro/logs
 	_BRO_PKG_INSTALLED=true
 	_BRO_PATH="/opt/bro/bin"
 }
@@ -262,54 +203,11 @@ __add_bro_to_path() {
 	read
 	if [[ ! $REPLY =~ ^[Nn]$ ]]; then
 		printf "$_SUBIMPORTANT Adding Bro IDS to the path in $_BRO_PATH_SCRIPT \n"
-		echo "export PATH=\"\$PATH:$_BRO_PATH\"" | $_ELEVATE tee $_BRO_PATH_SCRIPT > /dev/null
+		echo "export PATH=\"\$PATH:$_BRO_PATH\"" | tee $_BRO_PATH_SCRIPT > /dev/null
 		_BRO_PATH_SCRIPT_INSTALLED=true
 		export PATH="$PATH:$_BRO_PATH"
 		_BRO_IN_PATH=true
 	fi
-}
-
-__install_go() {
-		curl -s -o /tmp/golang.tar.gz https://storage.googleapis.com/golang/go1.8.3.linux-amd64.tar.gz
-		$_ELEVATE tar -zxf /tmp/golang.tar.gz -C /usr/local/
-		rm /tmp/golang.tar.gz
-		_GO_INSTALLED_STD=true
-		_GO_INSTALLED=true
-		_GO_PATH="/usr/local/go/bin"
-}
-
-__add_go_to_path() {
-		printf "$_SUBIMPORTANT Adding Go to the path in $_GO_PATH_SCRIPT \n"
-		echo "export PATH=\"\$PATH:$_GO_PATH\"" | $_ELEVATE tee $_GO_PATH_SCRIPT > /dev/null
-		_GO_PATH_SCRIPT_INSTALLED=true
-		export PATH="$PATH:$_GO_PATH"
-		_GO_IN_PATH=true
-}
-
-__create_go_path() {
-	printf "$_SUBIMPORTANT Go requires a per-user workspace (GOPATH) in order to build software. \n"
-
-	printf "$_SUBQUESTION Select a GOPATH [$HOME/go]: "
-	read
-	if [ -n "$REPLY" ]; then
-		export GOPATH="$REPLY"
-	else
-		export GOPATH="$HOME/go"
-	fi
-
-	printf "$_SUBIMPORTANT Creating a GOPATH at $GOPATH \n"
-	mkdir -p "$GOPATH/"{src,pkg,bin}
-	_GOPATH_EXISTS=true
-
-	export PATH="$PATH:$GOPATH/bin"
-
-	printf "$_SUBIMPORTANT Adding your GOPATH to $_GOPATH_PATH_SCRIPT \n"
-	echo "export GOPATH=\"$GOPATH\"" > "$_GOPATH_PATH_SCRIPT"
-	echo "export PATH=\"\$PATH:\$GOPATH/bin\"" >> "$_GOPATH_PATH_SCRIPT"
-	_GOPATH_PATH_SCRIPT_INSTALLED=true
-
-	printf "$_SUBIMPORTANT Adding $_GOPATH_PATH_SCRIPT to $HOME/.profile \n"
-	echo "source \"$_GOPATH_PATH_SCRIPT\"" >> "$HOME/.profile"
 }
 
 __install_mongodb() {
@@ -321,7 +219,7 @@ __install_mongodb() {
 			;;
 		CentOS)
 			if [ ! -s /etc/yum.repos.d/mongodb-org-3.4.repo ]; then
-				echo -e '[mongodb-org-3.4]\nname=MongoDB Repository\nbaseurl=https://repo.mongodb.org/yum/redhat/$releasever/mongodb-org/3.4/x86_64/\ngpgcheck=1\nenabled=1\ngpgkey=https://www.mongodb.org/static/pgp/server-3.4.asc' | $_ELEVATE tee /etc/yum.repos.d/mongodb-org-3.4.repo > /dev/null
+				echo -e '[mongodb-org-3.4]\nname=MongoDB Repository\nbaseurl=https://repo.mongodb.org/yum/redhat/$releasever/mongodb-org/3.4/x86_64/\ngpgcheck=1\nenabled=1\ngpgkey=https://www.mongodb.org/static/pgp/server-3.4.asc' | tee /etc/yum.repos.d/mongodb-org-3.4.repo > /dev/null
 			fi
 			;;
 	esac
@@ -329,49 +227,42 @@ __install_mongodb() {
 	_MONGO_INSTALLED=true
 }
 
-__build_rita() {
-	curl -L -s -o "$GOPATH/bin/dep" https://github.com/golang/dep/releases/download/v0.3.2/dep-linux-amd64
-	chmod +x "$GOPATH/bin/dep"
-
-	export _RITA_SRC_DIR="$GOPATH/src/github.com/activecm/rita"
-	mkdir -p "$_RITA_SRC_DIR"
-
-	# Get the code from git since the build process is dependent on git
-	git clone http://github.com/activecm/rita "$_RITA_SRC_DIR" > /dev/null 2>&1
-
-	local old_dir="$PWD"
-	cd "$_RITA_SRC_DIR"
-	if [ -n "${_RITA_VERSION+x}" ]; then
-		git checkout $_RITA_VERSION > /dev/null 2>&1
-	fi
-	make > /dev/null
-	cd "$old_dir"
-}
-
 __install_rita() {
-	$_ELEVATE mkdir -p "$_CONFIG_PATH"
-	#$_ELEVATE mkdir -p "$_VAR_PATH"
-	$_ELEVATE mkdir -p "$_VAR_PATH/logs"
-	$_ELEVATE chmod 777 "$_VAR_PATH/logs"
+	# Set _RITA_VERSION if it's not set
+	if [ -z ${_RITA_VERSION+x} ]; then
+		_LATEST_VERSION_COMMAND=\
+'curl -sSL https://api.github.com/repos/activecm/rita/releases/latest | grep tag_name | cut -d"\"" -f4'
+		_RITA_VERSION="$(eval $_LATEST_VERSION_COMMAND)"
+	fi
 
-	$_ELEVATE mv -f "$_RITA_SRC_DIR/rita" "$_BIN_PATH/rita"
-	$_ELEVATE chown root:root "$_BIN_PATH/rita"
-	$_ELEVATE chmod 755 "$_BIN_PATH/rita"
+	_RITA_DOWNLOAD_URL="https://github.com/activecm/rita/releases/download/$_RITA_VERSION"
+	_RITA_BINARY_URL="$_RITA_DOWNLOAD_URL/rita"	
+	_RITA_CONFIG_URL="$_RITA_DOWNLOAD_URL/config.yaml"
+	_RITA_LICENSE_URL="$_RITA_DOWNLOAD_URL/LICENSE"
+	
+	curl -sSL $_RITA_BINARY_URL -o $_BIN_PATH/rita
+	chmod 755 "$_BIN_PATH/rita"
 
-	$_ELEVATE cp -f "$_RITA_SRC_DIR/LICENSE" "$_CONFIG_PATH/LICENSE"
+	mkdir -p "$_CONFIG_PATH"
+	mkdir -p "$_VAR_PATH"
+	mkdir -p "$_VAR_PATH/logs"
+	chmod 777 "$_VAR_PATH/logs"
+
+	curl -sSL "$_RITA_LICENSE_URL" -o "$_CONFIG_PATH/LICENSE"
+
 	if [ -f "$_CONFIG_PATH/config.yaml" ]; then
 		printf "$_SUBITEM Backing up your current RITA config: $_CONFIG_PATH/config.yaml -> $_CONFIG_PATH/config.yaml.old \n"
-		$_ELEVATE mv -f "$_CONFIG_PATH/config.yaml" "$_CONFIG_PATH/config.yaml.old"
+		mv -f "$_CONFIG_PATH/config.yaml" "$_CONFIG_PATH/config.yaml.old"
 	fi
-	$_ELEVATE cp -f "$_RITA_SRC_DIR/etc/rita.yaml" "$_CONFIG_PATH/config.yaml"
+	curl -sSL "$_RITA_CONFIG_URL" -o "$_CONFIG_PATH/config.yaml"
 
 	# All users can read and write rita's config file
-	$_ELEVATE chmod 755 "$_CONFIG_PATH"
-	$_ELEVATE chmod 666 "$_CONFIG_PATH/config.yaml"
+	chmod 755 "$_CONFIG_PATH"
+	chmod 666 "$_CONFIG_PATH/config.yaml"
 
-	$_ELEVATE touch "$_VAR_PATH/safebrowsing"
-	$_ELEVATE chmod 755 "$_VAR_PATH"
-	$_ELEVATE chmod 666 "$_VAR_PATH/safebrowsing"
+	touch "$_VAR_PATH/safebrowsing"
+	chmod 755 "$_VAR_PATH"
+	chmod 666 "$_VAR_PATH/safebrowsing"
 }
 
 # INFORMATION GATHERING
@@ -406,61 +297,6 @@ __gather_pkg_mgr() {
 	fi
 }
 
-__gather_go() {
-	_GO_PATH=""
-	_GO_INSTALLED_STD=false
-	if [ -f "/usr/local/go/bin/go" ]; then
-		_GO_INSTALLED_STD=true
-		_GO_PATH="/usr/local/go/bin"
-	fi
-
-	_GO_INSTALLED_NON_STD=false
-	if [ -n "$GOROOT" -a -f "$GOROOT/bin/go" ]; then
-		_GO_INSTALLED_NON_STD=true
-		_GO_PATH="$GOROOT/bin"
-	fi
-
-	_GO_INSTALLED=false
-	if [ $_GO_INSTALLED_STD = "true" -o $_GO_INSTALLED_NON_STD = "true" ]; then
-		_GO_INSTALLED=true
-	fi
-
-	_GO_OUT_OF_DATE=false
-	if [ $_GO_INSTALLED = "true" ]; then
-		case `$_GO_PATH/go version | awk '{print $3}'` in
-		go1|go1.2*|go1.3*|go1.4*|go1.5*|go1.6*|"")
-			_GO_OUT_OF_DATE=true
-			;;
-		esac
-	fi
-
-	_GO_PATH_SCRIPT="/etc/profile.d/go-path.sh"
-	_GO_PATH_SCRIPT_INSTALLED=false
-
-	if [ -f "$_GO_PATH_SCRIPT" ]; then
-		source "$_GO_PATH_SCRIPT"
-		_GO_PATH_SCRIPT_INSTALLED=true
-	fi
-
-	_GO_IN_PATH=false
-	if [ -n "$(type -fp go)" ]; then
-		_GO_IN_PATH=true
-	fi
-
-	_GOPATH_PATH_SCRIPT="$HOME/.gopath-path.sh"
-	_GOPATH_PATH_SCRIPT_INSTALLED=false
-
-	if [ -f "$_GOPATH_PATH_SCRIPT" ]; then
-		source "$_GOPATH_PATH_SCRIPT"
-		_GOPATH_PATH_SCRIPT_INSTALLED=true
-	fi
-
-	_GOPATH_EXISTS=false
-	if [ -n "$GOPATH" ]; then
-		_GOPATH_EXISTS=true
-	fi
-
-}
 
 __gather_bro() {
 	_BRO_PATH=""
@@ -514,12 +350,6 @@ __explain() {
 	printf "$_ITEM This installer will: \n"
 	if [ $_BRO_INSTALLED = "false" -a $_INSTALL_BRO = "true" ]; then
 		printf "$_SUBITEM Install Bro IDS to /opt/bro \n"
-	fi
-	if [ $_GO_INSTALLED = "false" ]; then
-		printf "$_SUBITEM Install Go to /usr/local/go \n"
-	fi
-	if [ $_GOPATH_EXISTS = "false" ]; then
-		printf "$_SUBITEM Create a Go build environment (GOPATH) in $HOME/go \n"
 	fi
 	if [ $_MONGO_INSTALLED = "false" -a $_INSTALL_MONGO = "true" ]; then
 		printf "$_SUBITEM Install MongoDB \n"
@@ -583,16 +413,16 @@ __install_packages() {
 					;;
 			esac
 		fi
-		eval $_ELEVATE $_PKG_INSTALL $pkg >/dev/null 2>&1
+		eval $_PKG_INSTALL $pkg >/dev/null 2>&1
 		shift
 	done
 }
 
 __freshen_packages() {
 	if [ $_PKG_MGR -eq 1 ]; then   #apt
-		$_ELEVATE apt-get -qq update > /dev/null 2>&1
+		apt-get -qq update > /dev/null 2>&1
 	elif [ $_PKG_MGR -eq 2 ]; then #yum
-		$_ELEVATE yum -q makecache > /dev/null 2>&1
+		yum -q makecache > /dev/null 2>&1
 	fi
 }
 
@@ -608,15 +438,15 @@ __package_installed() {
 __add_deb_repo() {
 	if [ ! -s "/etc/apt/sources.list.d/$2.list" ]; then
 		if [ ! -z "$3" ]; then
-			curl -s -L "$3" | $_ELEVATE apt-key add - > /dev/null 2>&1
+			curl -s -L "$3" | apt-key add - > /dev/null 2>&1
 		fi
-		echo "$1" | $_ELEVATE tee "/etc/apt/sources.list.d/$2.list" > /dev/null
+		echo "$1" | tee "/etc/apt/sources.list.d/$2.list" > /dev/null
 		__freshen_packages
 	fi
 }
 
 __add_rpm_repo() {
-	$_ELEVATE yum-config-manager -q --add-repo=$1 > /dev/null 2>&1
+	yum-config-manager -q --add-repo=$1 > /dev/null 2>&1
 	__freshen_packages
 }
 


### PR DESCRIPTION
Changes installer.sh to pull a statically linked RITA binary for Linux x86-64 from github.com rather than installing go and building the rita binary.


Uses the github releases API to grab the latest release version.

Requires rita, config.yaml, and LICENSE to be present in every release here forward.