### PR TITLE
Lower the import buffer to safely import 10 datasets with .5 GiB RAM

### DIFF
--- a/etc/rita.yaml
+++ b/etc/rita.yaml
@@ -48,9 +48,9 @@ Bro:
     MetaDB: MetaDatabase
 
     # The number of records shipped off to MongoDB at a time. Increasing
-    # the size of the buffer will improve import timings but will leave more
-    # records unimported if there is an error
-    ImportBuffer: 100000
+    # the size of the buffer will improve import timings at the expense
+    # of using more RAM.
+    ImportBuffer: 30000
 
 BlackListed:
     # These are blacklists built into rita-blacklist. Set these to false


### PR DESCRIPTION
The amount of RAM used during import is given by the equation:
`# collections * # databases * size of log record * size of ImportBuffer`

Currently, importing 10 databases requires `3 * 10 * roughly 512 * 100000 bytes` or `1.43 GiB` of RAM. 
Setting the import buffer size to `30000` brings the the RAM needed to just under .5 GiB which is more reasonable. 

Ideally, we would allocate an import buffer and share it amongst all of the imported logs rather than use a buffer per collection. This would prevent the need for more RAM as more databases are imported. 
Alternatively, we can import one database at a time so there is a max of 3 buffers running around at any given time. However, this requires a larger patch to the import subsystem. 