### PR TITLE
Remove DisableIdIndex as the option is deprecated and is an error in 3.7+

### DIFF
--- a/analysis/beacon/beacon.go
+++ b/analysis/beacon/beacon.go
@@ -37,7 +37,7 @@ func BuildBeaconCollection(res *resources.Resources) {
 		{Key: []string{"uconn_id"}, Unique: true},
 		{Key: []string{"ts_score"}},
 	}
-	err := res.DB.CreateCollection(collectionName, false, collectionKeys)
+	err := res.DB.CreateCollection(collectionName, collectionKeys)
 	if err != nil {
 		res.Log.Error("Failed: ", collectionName, err.Error())
 		return

--- a/analysis/crossref/crossref.go
+++ b/analysis/crossref/crossref.go
@@ -23,8 +23,8 @@ func getXRefSelectors() []dataXRef.XRefSelector {
 // BuildXRefCollection runs threaded crossref analysis
 func BuildXRefCollection(res *resources.Resources) {
 	indexes := []mgo.Index{{Key: []string{"host"}, Unique: true}}
-	res.DB.CreateCollection(res.Config.T.Crossref.SourceTable, false, indexes)
-	res.DB.CreateCollection(res.Config.T.Crossref.DestTable, false, indexes)
+	res.DB.CreateCollection(res.Config.T.Crossref.SourceTable, indexes)
+	res.DB.CreateCollection(res.Config.T.Crossref.DestTable, indexes)
 
 	//maps from analysis types to channels of hosts found
 	sources := make(map[string]<-chan string)

--- a/analysis/dns/explodedDNS.go
+++ b/analysis/dns/explodedDNS.go
@@ -56,7 +56,7 @@ func zipExplodedDNSResults(res *resources.Resources) {
 		{Key: []string{"domain"}, Unique: true},
 		{Key: []string{"subdomains"}},
 	}
-	res.DB.CreateCollection(res.Config.T.DNS.ExplodedDNSTable, false, indexes)
+	res.DB.CreateCollection(res.Config.T.DNS.ExplodedDNSTable, indexes)
 	res.DB.AggregateCollection(tempVistedCountCollName, ssn,
 		// nolint: vet
 		[]bson.D{

--- a/analysis/dns/hostnames.go
+++ b/analysis/dns/hostnames.go
@@ -25,7 +25,7 @@ func BuildHostnamesCollection(res *resources.Resources) {
 	res.DB.AggregateCollection(sourceCollectionName, ssn, pipeline)
 
 	indexes := []mgo.Index{{Key: []string{"host"}, Unique: true}}
-	err := res.DB.CreateCollection(hostNamesCollection, false, indexes)
+	err := res.DB.CreateCollection(hostNamesCollection, indexes)
 
 	if err != nil {
 		res.Log.Error("Could not create ", hostNamesCollection, err)

--- a/analysis/scanning/scan.go
+++ b/analysis/scanning/scan.go
@@ -17,7 +17,7 @@ func BuildScanningCollection(res *resources.Resources) {
 		pipeline := getScanningCollectionScript(res.Config)
 
 	// Create it
-	err := res.DB.CreateCollection(newCollectionName, false, newCollectionKeys)
+	err := res.DB.CreateCollection(newCollectionName, newCollectionKeys)
 	if err != nil {
 		res.Log.Error("Failed: ", newCollectionName, err.Error())
 		return

--- a/analysis/structure/hosts.go
+++ b/analysis/structure/hosts.go
@@ -17,7 +17,7 @@ func BuildHostsCollection(res *resources.Resources) {
 		pipeline := getHosts(res.Config)
 
 	// Aggregate it!
-	errorCheck := res.DB.CreateCollection(newCollectionName, false, newCollectionKeys)
+	errorCheck := res.DB.CreateCollection(newCollectionName, newCollectionKeys)
 	if errorCheck != nil {
 		res.Log.Error("Failed: ", newCollectionName, errorCheck)
 		return

--- a/analysis/structure/ip.go
+++ b/analysis/structure/ip.go
@@ -19,7 +19,6 @@ func BuildIPv4Collection(res *resources.Resources) {
 
 	errorCheck := res.DB.CreateCollection(
 		res.Config.T.Structure.IPv4Table,
-		false,
 		[]mgo.Index{
 			{Key: []string{"ip"}, Unique: true},
 			{Key: []string{"ipv4_binary"}},
@@ -47,7 +46,6 @@ func BuildIPv6Collection(res *resources.Resources) {
 
 	errorCheck := res.DB.CreateCollection(
 		res.Config.T.Structure.IPv6Table,
-		false,
 		[]mgo.Index{
 			{Key: []string{"ip"}, Unique: true},
 			{Key: []string{"ipv6_binary.1"}},

--- a/analysis/structure/uconn.go
+++ b/analysis/structure/uconn.go
@@ -37,7 +37,7 @@ func BuildUniqueConnectionsCollection(res *resources.Resources) {
 		newCollectionKeys,
 		pipeline := getUniqueConnectionsScript(res.Config)
 
-	err := res.DB.CreateCollection(newCollectionName, true, newCollectionKeys)
+	err := res.DB.CreateCollection(newCollectionName, newCollectionKeys)
 	if err != nil {
 		res.Log.Error("Failed: ", newCollectionName, err.Error())
 		return

--- a/analysis/urls/url.go
+++ b/analysis/urls/url.go
@@ -18,7 +18,7 @@ func BuildUrlsCollection(res *resources.Resources) {
 		pipeline := getURLCollectionScript(res.Config)
 
 	// Create it
-	err := res.DB.CreateCollection(newCollectionName, false, []mgo.Index{})
+	err := res.DB.CreateCollection(newCollectionName, []mgo.Index{})
 	if err != nil {
 		res.Log.Error("Failed: ", newCollectionName, err.Error())
 		return

--- a/analysis/useragent/useragent.go
+++ b/analysis/useragent/useragent.go
@@ -17,7 +17,7 @@ func BuildUserAgentCollection(res *resources.Resources) {
 		pipeline := getUserAgentCollectionScript(res.Config)
 
 	// Create it
-	err := res.DB.CreateCollection(newCollectionName, false, newCollectionKeys)
+	err := res.DB.CreateCollection(newCollectionName, newCollectionKeys)
 	if err != nil {
 		res.Log.Error("Failed: ", newCollectionName, err.Error())
 		return

--- a/database/db.go
+++ b/database/db.go
@@ -78,7 +78,7 @@ func (d *DB) CollectionExists(table string) bool {
 
 //CreateCollection creates a new collection in the currently selected
 //database with the required indeces
-func (d *DB) CreateCollection(name string, id bool, indeces []mgo.Index) error {
+func (d *DB) CreateCollection(name string, indeces []mgo.Index) error {
 	// Make a copy of the current session
 	session := d.Session.Copy()
 	defer session.Close()
@@ -96,9 +96,7 @@ func (d *DB) CreateCollection(name string, id bool, indeces []mgo.Index) error {
 
 	// Create new collection by referencing to it, no need to call Create
 	err := session.DB(d.selected).C(name).Create(
-		&mgo.CollectionInfo{
-			DisableIdIndex: !id,
-		},
+		&mgo.CollectionInfo{},
 	)
 
 	// Make sure it actually got created


### PR DESCRIPTION
`DisableIdIndex` is currently deprecated. We used it to speed up analysis since we don't make use of the index. However, the `_id` index is required from MongoDB 3.7.5 on. While 3.7.x onward is considered unstable, these changes are coming down the line in 3.8. This commit ensures future compatibility. 