### PR TITLE
Filter unestablished tcp beacons fixes #117

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -94,7 +94,10 @@
 
 [[projects]]
   name = "github.com/stretchr/testify"
-  packages = ["assert"]
+  packages = [
+    "assert",
+    "require"
+  ]
   revision = "12b6f73e6084dad08a7c6e575284b177ecafbc71"
   version = "v1.2.1"
 
@@ -167,6 +170,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "a4e09dc561c661f2ae4ae099a769261c68e717ecc2d812caaf375f93d2fcfb5f"
+  inputs-digest = "15cfa40934602facd888e26c17bd2d0dcb7ecfeea3bc11ee2a8554180a2d2e30"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/analysis/beacon/beacon.go
+++ b/analysis/beacon/beacon.go
@@ -62,11 +62,11 @@ func BuildBeaconCollection(res *resources.Resources) {
 	writerWorker := newWriter(res.DB, res.Config)
 	analyzerWorker := newAnalyzer(
 		thresh, minTime, maxTime,
-		writerWorker.write,
+		writerWorker.write, writerWorker.close,
 	)
 	collectorWorker := newCollector(
 		res.DB, res.Config, thresh,
-		analyzerWorker.analyze,
+		analyzerWorker.analyze, analyzerWorker.close,
 	)
 
 	//kick off the threaded goroutines
@@ -89,12 +89,7 @@ func BuildBeaconCollection(res *resources.Resources) {
 	session.Close()
 
 	// Wait for things to finish
-	res.Log.Debug("Finding all source / destination pairs for analysis")
-	collectorWorker.flush()
-	res.Log.Debug("Analyzing source / destination pairs")
-	analyzerWorker.flush()
-	res.Log.Debug("Finishing writing results to database")
-	writerWorker.flush()
+	collectorWorker.close()
 }
 
 func findAnalysisPeriod(db *database.DB, connCollection string,

--- a/analysis/beacon/collector.go
+++ b/analysis/beacon/collector.go
@@ -87,9 +87,6 @@ func (c *collector) start() {
 					Iter()
 
 				for connIter.Next(&conn) {
-					//TODO: Test. Currently none of the test cases mark proto, so they
-					//pass
-
 					//filter out unestablished connections
 					//We expect at least SYN ACK SYN-ACK [FIN ACK FIN ACK/ RST]
 					if conn.Proto == "tcp" && conn.OriginPackets+conn.ResponsePackets <= 3 {

--- a/analysis/beacon/collector.go
+++ b/analysis/beacon/collector.go
@@ -18,6 +18,7 @@ type (
 		conf                *config.Config             // contains details needed to access MongoDB
 		connectionThreshold int                        // the minimum number of connections to be considered a beacon
 		collectedCallback   func(*beaconAnalysisInput) // called on each collected set of connections
+		closedCallback      func()                     // called when .close() is called and no more calls to collectedCallback will be made
 		collectChannel      chan string                // holds ip addresses
 		collectWg           sync.WaitGroup             // wait for collection to finish
 	}
@@ -27,12 +28,13 @@ type (
 // which group the given source, a detected destination, and all of their
 // connection analysis details (timestamps, data sizes, etc.)
 func newCollector(db *database.DB, conf *config.Config, connectionThreshold int,
-	collectedCallback func(*beaconAnalysisInput)) *collector {
+	collectedCallback func(*beaconAnalysisInput), closedCallback func()) *collector {
 	return &collector{
 		db:                  db,
 		conf:                conf,
 		connectionThreshold: connectionThreshold,
 		collectedCallback:   collectedCallback,
+		closedCallback:      closedCallback,
 		collectChannel:      make(chan string),
 	}
 }
@@ -43,10 +45,11 @@ func (c *collector) collect(srcHost string) {
 	c.collectChannel <- srcHost
 }
 
-// flush waits for the collection threads to finish
-func (c *collector) flush() {
+// close waits for the collection threads to finish
+func (c *collector) close() {
 	close(c.collectChannel)
 	c.collectWg.Wait()
+	c.closedCallback()
 }
 
 // start kicks off a new collection thread

--- a/analysis/beacon/collector_test.go
+++ b/analysis/beacon/collector_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/activecm/rita/datatypes/structure"
 	"github.com/activecm/rita/parser/parsetypes"
 	"github.com/activecm/rita/resources"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestCollector(t *testing.T) {
@@ -46,11 +46,11 @@ func TestCollector(t *testing.T) {
 }
 
 func collectionSuccessful(t *testing.T, collectorTestData *collectorTestData, collectedData *beaconAnalysisInput) {
-	assert.Equal(t, collectorTestData.src, collectedData.src)
-	assert.Equal(t, collectorTestData.dst, collectedData.dst)
+	require.Equal(t, collectorTestData.src, collectedData.src)
+	require.Equal(t, collectorTestData.dst, collectedData.dst)
 	for i := range collectorTestData.ts {
-		assert.Equal(t, collectorTestData.ts[i], collectedData.ts[i])
-		assert.Equal(t, collectorTestData.ds[i], collectedData.origIPBytes[i])
+		require.Equal(t, collectorTestData.ts[i], collectedData.ts[i])
+		require.Equal(t, collectorTestData.ds[i], collectedData.origIPBytes[i])
 	}
 }
 

--- a/analysis/beacon/collector_test.go
+++ b/analysis/beacon/collector_test.go
@@ -10,39 +10,69 @@ import (
 )
 
 func TestCollector(t *testing.T) {
+
 	res := resources.InitIntegrationTestingResources(t)
 	setUpCollectorTest(t, res)
 	defer tearDownCollectorConnRecords(t, res)
 
-	collectedChannel := make(chan *beaconAnalysisInput)
+	var collectedChannel chan *beaconAnalysisInput
 
-	collector := newCollector(
-		res.DB, res.Config, res.Config.S.Beacon.DefaultConnectionThresh,
-		func(collected *beaconAnalysisInput) {
-			collectedChannel <- collected
-		},
-	)
-	collector.start()
-	collector.collect(collectorTestDataHostList[0])
+	collect := func(srcHost string) {
+		collectedChannel = make(chan *beaconAnalysisInput, 2)
+		collector := newCollector(
+			res.DB, res.Config, res.Config.S.Beacon.DefaultConnectionThresh,
+			func(collected *beaconAnalysisInput) {
+				collectedChannel <- collected
+			},
+			func() {
+				close(collectedChannel)
+			},
+		)
+		collector.start()
+		collector.collect(srcHost)
+		collector.close()
+	}
+
+	collect(collectorTestDataHostList[0])
 
 	t.Run(collectorTestDataList[0].description, func(t *testing.T) {
-		collectedHost := <-collectedChannel
+		collectedHost, ok := <-collectedChannel
+		require.True(t, ok)
 		collectionSuccessful(t, &collectorTestDataList[0], collectedHost)
 	})
 
-	t.Run(collectorTestDataList[2].description, func(t *testing.T) {
-		collectedHost := <-collectedChannel
-		collectionSuccessful(t, &collectorTestDataList[2], collectedHost)
-	})
-
-	collector.collect(collectorTestDataHostList[1])
-
 	t.Run(collectorTestDataList[1].description, func(t *testing.T) {
-		collectedHost := <-collectedChannel
+		collectedHost, ok := <-collectedChannel
+		require.True(t, ok)
 		collectionSuccessful(t, &collectorTestDataList[1], collectedHost)
 	})
 
-	collector.flush()
+	collect(collectorTestDataHostList[1])
+
+	t.Run(collectorTestDataList[2].description, func(t *testing.T) {
+		collectedHost, ok := <-collectedChannel
+		require.True(t, ok)
+		collectionSuccessful(t, &collectorTestDataList[2], collectedHost)
+	})
+
+	t.Run(collectorTestDataList[3].description, func(t *testing.T) {
+		_, ok := <-collectedChannel
+		require.False(t, ok)
+	})
+
+	collect(collectorTestDataHostList[2])
+
+	t.Run(collectorTestDataList[5].description, func(t *testing.T) {
+		collectedHost, ok := <-collectedChannel
+		require.True(t, ok)
+		collectionSuccessful(t, &collectorTestDataList[5], collectedHost)
+	})
+
+	t.Run(collectorTestDataList[4].description, func(t *testing.T) {
+		_, ok := <-collectedChannel
+		require.False(t, ok)
+	})
+
 }
 
 func collectionSuccessful(t *testing.T, collectorTestData *collectorTestData, collectedData *beaconAnalysisInput) {
@@ -57,9 +87,9 @@ func collectionSuccessful(t *testing.T, collectorTestData *collectorTestData, co
 func setUpCollectorTest(t *testing.T, res *resources.Resources) {
 	session := res.DB.Session.Copy()
 	defer session.Close()
-	for _, record := range collectorTestDataList {
+	for i, record := range collectorTestDataList {
 		if len(record.ts) != len(record.ds) {
-			t.FailNow()
+			t.Fatalf("number of timestamps and data measures are not equal for test record %d", i)
 		}
 		uconn := structure.UniqueConnection{
 			Src:             record.src,
@@ -74,6 +104,9 @@ func setUpCollectorTest(t *testing.T, res *resources.Resources) {
 				OrigIPBytes: dataSize,
 				Source:      record.src,
 				Destination: record.dst,
+				Proto:       record.proto,
+				OrigPkts:    record.origPackets,
+				RespPkts:    record.respPackets,
 			}
 			session.DB(res.DB.GetSelectedDB()).C(res.Config.T.Structure.ConnTable).Insert(&connRecord)
 		}

--- a/analysis/beacon/collector_test_data.go
+++ b/analysis/beacon/collector_test_data.go
@@ -5,6 +5,9 @@ type collectorTestData struct {
 	dst         string
 	ts          []int64
 	ds          []int64
+	proto       string
+	origPackets int64
+	respPackets int64
 	description string
 }
 
@@ -12,24 +15,56 @@ var collectorTestDataHostList = []string{"1.1.1.1", "2.2.2.2", "3.3.3.3"}
 
 var collectorTestDataList = []collectorTestData{
 	collectorTestData{
-		src:         collectorTestDataHostList[0],
-		dst:         collectorTestDataHostList[1],
-		ts:          analyzerTestDataList[0].ts,
-		ds:          analyzerTestDataList[0].ds,
+		src:   collectorTestDataHostList[0],
+		dst:   collectorTestDataHostList[1],
+		ts:    analyzerTestDataList[0].ts,
+		ds:    analyzerTestDataList[0].ds,
+		proto: "udp",
+		//resp and orig packets are zero to ensure udp isn't affected by the tcp threshold
 		description: "Perfect 24hr Beacon from " + collectorTestDataHostList[0] + " to " + collectorTestDataHostList[1],
-	},
-	collectorTestData{
-		src:         collectorTestDataHostList[1],
-		dst:         collectorTestDataHostList[0],
-		ts:          analyzerTestDataList[0].ts,
-		ds:          analyzerTestDataList[0].ds,
-		description: "Perfect 24hr Beacon from " + collectorTestDataHostList[1] + " to " + collectorTestDataHostList[0],
 	},
 	collectorTestData{
 		src:         collectorTestDataHostList[0],
 		dst:         collectorTestDataHostList[2],
 		ts:          analyzerTestDataList[3].ts,
 		ds:          analyzerTestDataList[3].ds,
+		proto:       "udp",
 		description: "Perfect 1hr Beacon from " + collectorTestDataHostList[0] + " to " + collectorTestDataHostList[2],
+	},
+	collectorTestData{
+		src:         collectorTestDataHostList[1],
+		dst:         collectorTestDataHostList[0],
+		ts:          analyzerTestDataList[0].ts,
+		ds:          analyzerTestDataList[0].ds,
+		proto:       "udp",
+		description: "Perfect 24hr Beacon from " + collectorTestDataHostList[1] + " to " + collectorTestDataHostList[0],
+	},
+	collectorTestData{
+		src:         collectorTestDataHostList[1],
+		dst:         collectorTestDataHostList[2],
+		ts:          []int64{0, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 110, 120, 130, 140, 150, 160, 170, 180, 190, 200, 210, 220, 230, 240, 250},
+		ds:          []int64{0, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 110, 120, 130, 140, 150, 160, 170, 180, 190, 200, 210, 220, 230, 240, 250},
+		proto:       "tcp",
+		origPackets: 1,
+		respPackets: 1,
+		description: "Invalid TCP Beacon With orig + resp IP packets = 2 from " + collectorTestDataHostList[1] + " to " + collectorTestDataHostList[2],
+	},
+	collectorTestData{
+		src:         collectorTestDataHostList[2],
+		dst:         collectorTestDataHostList[0],
+		ts:          []int64{1, 2, 3, 4, 5},
+		ds:          []int64{1, 1, 1, 1, 1},
+		proto:       "udp",
+		description: "Invalid short beacon from " + collectorTestDataHostList[2] + " to " + collectorTestDataHostList[0],
+	},
+	collectorTestData{
+		src:         collectorTestDataHostList[2],
+		dst:         collectorTestDataHostList[1],
+		ts:          []int64{0, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 110, 120, 130, 140, 150, 160, 170, 180, 190, 200, 210, 220, 230, 240, 250},
+		ds:          []int64{0, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 110, 120, 130, 140, 150, 160, 170, 180, 190, 200, 210, 220, 230, 240, 250},
+		proto:       "tcp",
+		origPackets: 5,
+		respPackets: 5,
+		description: "Valid TCP Beacon With orig + resp IP packets = 10 from " + collectorTestDataHostList[2] + " to " + collectorTestDataHostList[1],
 	},
 }

--- a/analysis/beacon/writer.go
+++ b/analysis/beacon/writer.go
@@ -34,8 +34,8 @@ func (w *writer) write(data *dataBeacon.BeaconAnalysisOutput) {
 	w.writeChannel <- data
 }
 
-// flush waits for the write threads to finish
-func (w *writer) flush() {
+// close waits for the write threads to finish
+func (w *writer) close() {
 	close(w.writeChannel)
 	w.writeWg.Wait()
 }

--- a/analysis/beacon/writer_test.go
+++ b/analysis/beacon/writer_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	dataBeacon "github.com/activecm/rita/datatypes/beacon"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/activecm/rita/resources"
 )
@@ -16,9 +16,9 @@ func TestWriter(t *testing.T) {
 	for i := range writerTestDataList {
 		writer.write(&writerTestDataList[i])
 	}
-	writer.flush()
+	writer.close()
 
 	var writtenData []dataBeacon.BeaconAnalysisOutput
 	res.DB.Session.DB(res.DB.GetSelectedDB()).C(res.Config.T.Beacon.BeaconTable).Find(nil).All(&writtenData)
-	assert.ElementsMatch(t, writerTestDataList, writtenData)
+	require.ElementsMatch(t, writerTestDataList, writtenData)
 }

--- a/config/testing.go
+++ b/config/testing.go
@@ -39,6 +39,8 @@ Beacon:
 
 // LoadTestingConfig loads the hard coded testing config
 func LoadTestingConfig(mongoURI string) (*Config, error) {
+	Version = "v0.0.0+testing"
+	ExactVersion = "v0.0.0+testing"
 	var config = new(Config)
 	static, err := parseStaticConfig([]byte(testConfig))
 	if err != nil {

--- a/datatypes/data/data.go
+++ b/datatypes/data/data.go
@@ -5,17 +5,19 @@ type (
 	// parser.Conn data structure. If fields are needed that are
 	// not in this Conn structure use parser.Conn instead.
 	Conn struct {
-		Ts            int64   `bson:"ts,omitempty"`
-		UID           string  `bson:"uid"`
-		Src           string  `bson:"id_orig_h,omitempty"`
-		Spt           int     `bson:"id_orig_p,omitempty"`
-		Dst           string  `bson:"id_resp_h,omitempty"`
-		Dpt           int     `bson:"id_resp_p,omitempty"`
-		Dur           float64 `bson:"duration,omitempty"`
-		Proto         string  `bson:"proto,omitempty"`
-		LocalSrc      bool    `bson:"local_orig,omitempty"`
-		LocalDst      bool    `bson:"local_resp,omitempty"`
-		OriginIPBytes int64   `bson:"orig_ip_bytes,omitempty"`
+		Ts              int64   `bson:"ts,omitempty"`
+		UID             string  `bson:"uid"`
+		Src             string  `bson:"id_orig_h,omitempty"`
+		Spt             int     `bson:"id_orig_p,omitempty"`
+		Dst             string  `bson:"id_resp_h,omitempty"`
+		Dpt             int     `bson:"id_resp_p,omitempty"`
+		Dur             float64 `bson:"duration,omitempty"`
+		Proto           string  `bson:"proto,omitempty"`
+		LocalSrc        bool    `bson:"local_orig,omitempty"`
+		LocalDst        bool    `bson:"local_resp,omitempty"`
+		OriginIPBytes   int64   `bson:"orig_ip_bytes,omitempty"`
+		OriginPackets   int64   `bson:"orig_pkts,omitempty"`
+		ResponsePackets int64   `bson:"resp_pkts,omitempty"`
 	}
 
 	// DNS provides structure for a subset of the fields in the


### PR DESCRIPTION
Issue #117 is a bug which creates a large amount of noise in the beaconing analysis. Failed TCP connections such as those generated by a TCP SYN scan appear with regularity in both time and data size. However, these connections never complete the TCP 3 way handshake. This prevents these connections from carrying meaningful data (outside the realm of abusing the protocol). When these connections are filtered from the beacon results, more important findings make their way to the top.

The patch was tested on [maccdc2012_00013.pcap](https://download.netresec.com/pcap/maccdc-2012/maccdc2012_00013.pcap.gz) which contains a large number of port scans. 

Additionally, the beacon tests were refactored and extended (particularly for the collector). 

### Before 
![withouttcppatch](https://user-images.githubusercontent.com/761220/43172670-b6d3fda4-8f6d-11e8-8262-ccabc2b847f3.png)

### After
![withtcppatch](https://user-images.githubusercontent.com/761220/43172671-b6e81938-8f6d-11e8-86c5-09d89d72ad25.png)
