### PR TITLE
git and make are no longer required for the install

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -171,7 +171,7 @@ __install_installer_deps() {
 	# Update package cache
 	__load "$_SUBITEM Updating packages" __freshen_packages
 
-	for pkg in git curl make coreutils lsb-release; do
+	for pkg in curl coreutils lsb-release; do
 		__load "$_SUBITEM Ensuring $pkg is installed" __install_packages $pkg
 	done
 }


### PR DESCRIPTION
When we moved from compiling rita locally to downloading it pre-compiled, we no longer need git or make as dependencies.