### PR TITLE
Install script update 18.04

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -166,7 +166,7 @@ __install() {
 	printf "$_IMPORTANT '$_START_MONGO'. You can access the MongoDB shell with \n"
 	printf "$_IMPORTANT 'mongo'. If, at any time, you need to stop MongoDB, \n"
 	printf "$_IMPORTANT run '$_STOP_MONGO'. \n"
-	if [ $_UBUNTU_VERSION = "Release:	18.04"]
+	if [ "$_UBUNTU_VERSION" == "Release:	18.04" ]
 	then
 		printf "$_IMPORTANT Bro does not currently have a package for 18.04 and must be installed manually from the source.\n"
 	fi

--- a/install.sh
+++ b/install.sh
@@ -168,7 +168,8 @@ __install() {
 	printf "$_IMPORTANT run '$_STOP_MONGO'. \n"
 	if [ "$_UBUNTU_VERSION" == "Release:	18.04" ]
 	then
-		printf "$_IMPORTANT Bro does not currently have a package for 18.04 and must be installed manually from the source.\n"
+		printf "$_IMPORTANT Bro does not currently have a package for 18.04 and must be installed\n"
+		printf "$_IMPORTANT manually from the source.\n"
 	fi
 	__title
 	printf "Thank you for installing RITA! Happy hunting! \n"

--- a/install.sh
+++ b/install.sh
@@ -14,7 +14,7 @@ _QUESTION="[?]"
 _SUBITEM="\t$_ITEM"
 _SUBIMPORTANT="\t$_IMPORTANT"
 _SUBQUESTION="\t$_QUESTION"
-
+_UBUNTU_VERSION="$lsb_release -r"
 
 # ERROR HANDLING
 __err() {
@@ -39,8 +39,14 @@ __entry() {
 	_REINSTALL_RITA=false
 
 	# Optional Dependencies
-	_INSTALL_BRO=true
-	_INSTALL_MONGO=true
+	if _UBUNTU_VERSION=="Release:	18.04"; then
+		printf "Bro does not currently have a package for 18.04 and must be installed manually from the source."
+		_INSTALL_BRO=false
+		_INSTALL_MONGO=false
+	else
+		_INSTALL_BRO=true
+		_INSTALL_MONGO=true
+	fi
 
 	# Install locations
 	_INSTALL_PREFIX=/usr/local

--- a/install.sh
+++ b/install.sh
@@ -39,7 +39,8 @@ __entry() {
 	_REINSTALL_RITA=false
 
 	# Optional Dependencies
-	if $_UBUNTU_VERSION=="Release:	18.04"; then
+	if [ "$_UBUNTU_VERSION" == "Release:	18.04" ]
+	then
 		_INSTALL_BRO=false
 		_INSTALL_MONGO=false
 	else
@@ -165,7 +166,8 @@ __install() {
 	printf "$_IMPORTANT '$_START_MONGO'. You can access the MongoDB shell with \n"
 	printf "$_IMPORTANT 'mongo'. If, at any time, you need to stop MongoDB, \n"
 	printf "$_IMPORTANT run '$_STOP_MONGO'. \n"
-	if $_UBUNTU_VERSION == "Release:	18.04"; then
+	if [ $_UBUNTU_VERSION = "Release:	18.04"]
+	then
 		printf "$_IMPORTANT Bro does not currently have a package for 18.04 and must be installed manually from the source.\n"
 	fi
 	__title

--- a/install.sh
+++ b/install.sh
@@ -39,7 +39,7 @@ __entry() {
 	_REINSTALL_RITA=false
 
 	# Optional Dependencies
-	if $_UBUNTU_VERSION == "Release:	18.04"; then
+	if $_UBUNTU_VERSION=="Release:	18.04"; then
 		_INSTALL_BRO=false
 		_INSTALL_MONGO=false
 	else

--- a/install.sh
+++ b/install.sh
@@ -39,7 +39,7 @@ __entry() {
 	_REINSTALL_RITA=false
 	printf "$_UBUNTU_VERSION\n"
 	# Optional Dependencies
-	if $_UBUNTU_VERSION=="Release:	18.04"; then
+	if $_UBUNTU_VERSION == "Release:	18.04"; then
 		_INSTALL_BRO=false
 		_INSTALL_MONGO=false
 	else
@@ -165,7 +165,7 @@ __install() {
 	printf "$_IMPORTANT '$_START_MONGO'. You can access the MongoDB shell with \n"
 	printf "$_IMPORTANT 'mongo'. If, at any time, you need to stop MongoDB, \n"
 	printf "$_IMPORTANT run '$_STOP_MONGO'. \n"
-	if $_UBUNTU_VERSION=="Release:	18.04"; then
+	if $_UBUNTU_VERSION == "Release:	18.04"; then
 		printf "$_IMPORTANT Bro does not currently have a package for 18.04 and must be installed manually from the source.\n"
 	fi
 	__title

--- a/install.sh
+++ b/install.sh
@@ -37,7 +37,7 @@ set -o pipefail
 # ENTRYPOINT
 __entry() {
 	_REINSTALL_RITA=false
-	printf "$_UBUNTU_VERSION\n"
+
 	# Optional Dependencies
 	if $_UBUNTU_VERSION == "Release:	18.04"; then
 		_INSTALL_BRO=false

--- a/install.sh
+++ b/install.sh
@@ -14,7 +14,7 @@ _QUESTION="[?]"
 _SUBITEM="\t$_ITEM"
 _SUBIMPORTANT="\t$_IMPORTANT"
 _SUBQUESTION="\t$_QUESTION"
-_UBUNTU_VERSION="$lsb_release -r"
+_UBUNTU_VERSION="$(lsb_release -r)"
 
 # ERROR HANDLING
 __err() {
@@ -37,10 +37,9 @@ set -o pipefail
 # ENTRYPOINT
 __entry() {
 	_REINSTALL_RITA=false
-
+	printf "$_UBUNTU_VERSION\n"
 	# Optional Dependencies
-	if _UBUNTU_VERSION=="Release:	18.04"; then
-		printf "Bro does not currently have a package for 18.04 and must be installed manually from the source."
+	if $_UBUNTU_VERSION=="Release:	18.04"; then
 		_INSTALL_BRO=false
 		_INSTALL_MONGO=false
 	else
@@ -166,7 +165,9 @@ __install() {
 	printf "$_IMPORTANT '$_START_MONGO'. You can access the MongoDB shell with \n"
 	printf "$_IMPORTANT 'mongo'. If, at any time, you need to stop MongoDB, \n"
 	printf "$_IMPORTANT run '$_STOP_MONGO'. \n"
-
+	if $_UBUNTU_VERSION=="Release:	18.04"; then
+		printf "$_IMPORTANT Bro does not currently have a package for 18.04 and must be installed manually from the source.\n"
+	fi
 	__title
 	printf "Thank you for installing RITA! Happy hunting! \n"
 }


### PR DESCRIPTION
I updated the install.sh file to account for RITA installation on Ubuntu 18.04. Bro must be installed from the source, I made a note at the end of the installation information about installing it from the source. Mongo is already installed in 18.04, for so I had the install script skip that part of the install.