### PR TITLE
Update Mongo version to 3.6

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -141,6 +141,8 @@ __install() {
 			__load "$_ITEM Installing MongoDB" __install_mongodb
 		elif ! __satisfies_version "$_MONGO_INSTALLED_VERSION" "$_MONGO_VERSION" ; then
 			__load "$_ITEM Updating MongoDB" __install_mongodb
+			# Need to also install all the components of the mongodb-org metapackage for Ubuntu
+			__install_packages mongodb-org-mongos mongodb-org-server mongodb-org-shell mongodb-org-tools
 		else
 			printf "$_ITEM MongoDB is already installed \n"
 		fi

--- a/install.sh
+++ b/install.sh
@@ -212,13 +212,13 @@ __add_bro_to_path() {
 __install_mongodb() {
 	case "$_OS" in
 		Ubuntu)
-			__add_deb_repo "deb [ arch=$(dpkg --print-architecture) ] http://repo.mongodb.org/apt/ubuntu $(lsb_release -cs)/mongodb-org/3.4 multiverse" \
+			__add_deb_repo "deb [ arch=$(dpkg --print-architecture) ] http://repo.mongodb.org/apt/ubuntu $(lsb_release -cs)/mongodb-org/3.6 multiverse" \
 				"MongoDB" \
-				"https://www.mongodb.org/static/pgp/server-3.4.asc"
+				"https://www.mongodb.org/static/pgp/server-3.6.asc"
 			;;
 		CentOS)
-			if [ ! -s /etc/yum.repos.d/mongodb-org-3.4.repo ]; then
-				echo -e '[mongodb-org-3.4]\nname=MongoDB Repository\nbaseurl=https://repo.mongodb.org/yum/redhat/$releasever/mongodb-org/3.4/x86_64/\ngpgcheck=1\nenabled=1\ngpgkey=https://www.mongodb.org/static/pgp/server-3.4.asc' | tee /etc/yum.repos.d/mongodb-org-3.4.repo > /dev/null
+			if [ ! -s /etc/yum.repos.d/mongodb-org-3.6.repo ]; then
+				echo -e '[mongodb-org-3.6]\nname=MongoDB Repository\nbaseurl=https://repo.mongodb.org/yum/redhat/$releasever/mongodb-org/3.6/x86_64/\ngpgcheck=1\nenabled=1\ngpgkey=https://www.mongodb.org/static/pgp/server-3.6.asc' | tee /etc/yum.repos.d/mongodb-org-3.6.repo > /dev/null
 			fi
 			;;
 	esac

--- a/install.sh
+++ b/install.sh
@@ -266,9 +266,15 @@ __install_mongodb() {
 				"https://www.mongodb.org/static/pgp/server-${_MONGO_VERSION}.asc"
 			;;
 		CentOS)
-			# __add_rpm_repo "https://repo.mongodb.org/yum/redhat/$releasever/mongodb-org/${_MONGO_VERSION}/x86_64/"
 			if [ ! -s /etc/yum.repos.d/mongodb-org-${_MONGO_VERSION}.repo ]; then
-				echo -e '[mongodb-org-${_MONGO_VERSION}]\nname=MongoDB Repository\nbaseurl=https://repo.mongodb.org/yum/redhat/$releasever/mongodb-org/${_MONGO_VERSION}/x86_64/\ngpgcheck=1\nenabled=1\ngpgkey=https://www.mongodb.org/static/pgp/server-${_MONGO_VERSION}.asc' | tee /etc/yum.repos.d/mongodb-org-${_MONGO_VERSION}.repo > /dev/null
+				cat << EOF > /etc/yum.repos.d/mongodb-org-${_MONGO_VERSION}.repo
+[mongodb-org-${_MONGO_VERSION}]
+name=MongoDB Repository
+baseurl=https://repo.mongodb.org/yum/redhat/\$releasever/mongodb-org/${_MONGO_VERSION}/x86_64/
+gpgcheck=1
+enabled=1
+gpgkey=https://www.mongodb.org/static/pgp/server-${_MONGO_VERSION}.asc
+EOF
 			fi
 			__freshen_packages
 			;;

--- a/install.sh
+++ b/install.sh
@@ -542,9 +542,14 @@ __package_version() {
 	fi
 }
 
+# Compares two version strings to determine if the first is
+# less than or equal to the second. Version strings are expected
+# to be in the form: 1.2.3, 1.2, or 1
 __satisfies_version() {
 	local installed="$1"
 	local desired="$2"
+
+	# Break apart version strings like 1.2.3 into major.minor.patch
 	local installed_major="$(echo $installed | cut -d'.' -f1)"
 	local installed_minor="$(echo $installed | cut -d'.' -f2)"
 	local installed_patch="$(echo $installed | cut -d'.' -f3)"
@@ -552,14 +557,13 @@ __satisfies_version() {
 	local desired_minor="$(echo $desired | cut -d'.' -f2)"
 	local desired_patch="$(echo $desired | cut -d'.' -f3)"
 
-	# Set any empty values to 0. echo > /dev/null is to prevent invoking values as commands
-	# http://wiki.bash-hackers.org/syntax/pe#assign_a_default_value
-	echo ${installed_major:=0} > /dev/null
-	echo ${installed_minor:=0} > /dev/null
-	echo ${installed_patch:=0} > /dev/null
-	echo ${desired_major:=0} > /dev/null
-	echo ${desired_minor:=0} > /dev/null
-	echo ${desired_patch:=0} > /dev/null
+	# Set any empty values to 0
+	if [ -z "$installed_major" ]; then installed_major=0; fi
+	if [ -z "$installed_minor" ]; then installed_minor=0; fi
+	if [ -z "$installed_patch" ]; then installed_patch=0; fi
+	if [ -z "$desired_major" ]; then desired_major=0; fi
+	if [ -z "$desired_minor" ]; then desired_minor=0; fi
+	if [ -z "$desired_patch" ]; then desired_patch=0; fi
 
 	if [ "$installed_major" -lt "$desired_major" ]; then
 		false; return


### PR DESCRIPTION
Testing:

Mongo 3.6 (new install):
- [ ] ~~Ubuntu 14.04 (Security Onion)~~
- [x] Ubuntu 16.04
- [x] CentOS 7

Mongo 3.6 (upgrade):
- [ ] ~~Ubuntu 14.04 (Security Onion)~~
- [x] Ubuntu 16.04
- [x] CentOS 7

Suggestion for testing:
1. Install RITA v1.0.3 or v1.1.0 on a system.
2. Verify that Mongo version 3.4 is installed: `mongod --version`
3. Update RITA using the installer in this pull request.
4. Verify that Mongo version 3.6 is installed: `mongod --version`