### PR TITLE
Activate bash tab autocomplete

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 VERSION := $(shell git describe --abbrev=0 --tags)
 EXACT_VERSION := $(shell git describe --always --long --dirty --tags)
+AUTOPATH := /etc/bash_completion.d/rita
 GOPATH := $(GOPATH)
 BINARY := rita
 
@@ -18,8 +19,12 @@ cache = $(if $(cached-$1),,$(eval cached-$1 := 1)$(eval cache-$1 := $($1)))$(cac
 $(BINARY): vendor $(SRC)
 	go build ${LDFLAGS}
 
+$(AUTOPATH):
+	mkdir -p /etc/bash_completion.d/
+	sudo cp vendor/github.com/urfave/cli/autocomplete/bash_autocomplete $(AUTOPATH)
+
 .PHONY: install
-install: $(BINARY)
+install: $(BINARY) $(AUTOPATH)
 	mv $(BINARY) $(GOPATH)/bin/$(BINARY)
 
 .PHONY: docker-check

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ cache = $(if $(cached-$1),,$(eval cached-$1 := 1)$(eval cache-$1 := $($1)))$(cac
 $(BINARY): vendor $(SRC)
 	go build ${LDFLAGS}
 
-$(AUTOPATH):
+$(AUTOPATH): vendor
 	mkdir -p /etc/bash_completion.d/
 	sudo cp vendor/github.com/urfave/cli/autocomplete/bash_autocomplete $(AUTOPATH)
 

--- a/install.sh
+++ b/install.sh
@@ -339,6 +339,8 @@ __install_rita() {
 	touch "$_VAR_PATH/safebrowsing"
 	chmod 755 "$_VAR_PATH"
 	chmod 666 "$_VAR_PATH/safebrowsing"
+
+	curl -sSL "https://raw.githubusercontent.com/urfave/cli/master/autocomplete/bash_autocomplete" -o "/etc/bash_completion.d/rita"
 }
 
 # INFORMATION GATHERING

--- a/install.sh
+++ b/install.sh
@@ -340,6 +340,7 @@ __install_rita() {
 	chmod 755 "$_VAR_PATH"
 	chmod 666 "$_VAR_PATH/safebrowsing"
 
+	mkdir -p /etc/bash_completion.d/
 	curl -sSL "https://raw.githubusercontent.com/urfave/cli/master/autocomplete/bash_autocomplete" -o "/etc/bash_completion.d/rita"
 }
 

--- a/rita.go
+++ b/rita.go
@@ -18,6 +18,7 @@ func main() {
 	// Change the version string with updates so that a quick help command will
 	// let the testers know what version of HT they're on
 	app.Version = config.Version
+	app.EnableBashCompletion = true
 
 	// Define commands used with this application
 	app.Commands = commands.Commands()


### PR DESCRIPTION
Addresses #244
While the issue states that some commands should be renamed all of the reasoning given speaks to general usability issues that would be solved by tab completion.

If nothing else tab completion is nice.