### PR TITLE
Alternative Migration: FIX #237 Allow Analysis While Importing Separate Data

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,19 +2,24 @@
 
 
 [[projects]]
+  digest = "1:5a71fb24ce7cbabaa4e30999bbc93e660ddd843af391b8719fb0d2faf0f81901"
   name = "github.com/activecm/mgorus"
   packages = ["."]
+  pruneopts = ""
   revision = "14fb55db664fcb78819379c2fcc01f917d682c67"
   version = "v0.1.1"
 
 [[projects]]
+  digest = "1:df541133b5b4919a9f1a215283caeaaa24cb4b58bc7358c97b970e7baf930391"
   name = "github.com/activecm/mgosec"
   packages = ["."]
+  pruneopts = ""
   revision = "3940290cb0e63eafbbabeb8c4a0a788f80e6bc7d"
   version = "v0.1.1"
 
 [[projects]]
   branch = "master"
+  digest = "1:150cbde83fd4a0c2620001ce4b2ec6bfc102321e7636c260c25ad66c9e4aa933"
   name = "github.com/activecm/rita-bl"
   packages = [
     ".",
@@ -22,125 +27,159 @@
     "list",
     "sources/lists",
     "sources/lists/util",
-    "sources/rpc"
+    "sources/rpc",
   ]
+  pruneopts = ""
   revision = "c067dd0a13599f118564cb3f6f022c94aef822ac"
 
 [[projects]]
+  digest = "1:79421244ba5848aae4b0a5c41e633a04e4894cb0b164a219dc8c15ec7facb7f1"
   name = "github.com/blang/semver"
   packages = ["."]
+  pruneopts = ""
   revision = "2ee87856327ba09384cabd113bc6b5d174e9ec0f"
   version = "v3.5.1"
 
 [[projects]]
+  digest = "1:56c130d885a4aacae1dd9c7b71cfe39912c7ebc1ff7d2b46083c8812996dc43b"
   name = "github.com/davecgh/go-spew"
   packages = ["spew"]
+  pruneopts = ""
   revision = "346938d642f2ec3594ed81d874461961cd0faa76"
   version = "v1.1.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:c1e35087694b689ce1cf4f4277612b6ac0b55725fa791271ae0e3ddcd1cc0c7b"
   name = "github.com/globalsign/mgo"
   packages = [
     ".",
     "bson",
     "internal/json",
     "internal/sasl",
-    "internal/scram"
+    "internal/scram",
   ]
+  pruneopts = ""
   revision = "113d3961e7311526535a1ef7042196563d442761"
 
 [[projects]]
+  digest = "1:f958a1c137db276e52f0b50efee41a1a389dcdded59a69711f3e872757dab34b"
   name = "github.com/golang/protobuf"
   packages = [
     "proto",
-    "ptypes/duration"
+    "ptypes/duration",
   ]
+  pruneopts = ""
   revision = "b4deda0973fb4c70b50d226b1af49f3da59f5265"
   version = "v1.1.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:e6606f5d677a5d893782794ba17f843057bbcea4151c87ca60eef47c6bd8a1dd"
   name = "github.com/google/safebrowsing"
   packages = [
     ".",
-    "internal/safebrowsing_proto"
+    "internal/safebrowsing_proto",
   ]
+  pruneopts = ""
   revision = "fe6951d7ef01b4e46d3008e8a08b55bcdf3c0ee6"
 
 [[projects]]
+  digest = "1:81e673df85e765593a863f67cba4544cf40e8919590f04d67664940786c2b61a"
   name = "github.com/mattn/go-runewidth"
   packages = ["."]
+  pruneopts = ""
   revision = "9e777a8366cce605130a531d2cd6363d07ad7317"
   version = "v0.0.2"
 
 [[projects]]
   branch = "master"
+  digest = "1:816e800c7b5689e114c0dc6acf494553d1e7a52575764c5d6de67fb32bd8bbb2"
   name = "github.com/olekukonko/tablewriter"
   packages = ["."]
+  pruneopts = ""
   revision = "d4647c9c7a84d847478d890b816b7d8b62b0b279"
 
 [[projects]]
+  digest = "1:256484dbbcd271f9ecebc6795b2df8cad4c458dd0f5fd82a8c2fa0c29f233411"
   name = "github.com/pmezard/go-difflib"
   packages = ["difflib"]
+  pruneopts = ""
   revision = "792786c7400a136282c1664665ae0a8db921c6c2"
   version = "v1.0.0"
 
 [[projects]]
+  digest = "1:dbcda8b78eff6b96910dae77e3d05d2b0766ed18554a3f668b2d37f25c044685"
   name = "github.com/rifflock/lfshook"
   packages = ["."]
+  pruneopts = ""
   revision = "bf539943797a1f34c1f502d07de419b5238ae6c6"
   version = "v2.3"
 
 [[projects]]
+  digest = "1:8cf46b6c18a91068d446e26b67512cf16f1540b45d90b28b9533706a127f0ca6"
   name = "github.com/sirupsen/logrus"
   packages = ["."]
+  pruneopts = ""
   revision = "c155da19408a8799da419ed3eeb0cb5db0ad5dbc"
   version = "v1.0.5"
 
 [[projects]]
   branch = "master"
+  digest = "1:50b5be512f924d289f20e8b2aef8951d98b9bd8c44666cf169514906df597a4c"
   name = "github.com/skratchdot/open-golang"
   packages = ["open"]
+  pruneopts = ""
   revision = "75fb7ed4208cf72d323d7d02fd1a5964a7a9073c"
 
 [[projects]]
+  digest = "1:c587772fb8ad29ad4db67575dad25ba17a51f072ff18a22b4f0257a4d9c24f75"
   name = "github.com/stretchr/testify"
   packages = [
     "assert",
-    "require"
+    "require",
   ]
+  pruneopts = ""
   revision = "f35b8ab0b5a2cef36673838d662e249dd9c94686"
   version = "v1.2.2"
 
 [[projects]]
+  digest = "1:e85837cb04b78f61688c6eba93ea9d14f60d611e2aaf8319999b1a60d2dafbfa"
   name = "github.com/urfave/cli"
   packages = ["."]
+  pruneopts = ""
   revision = "cfb38830724cc34fedffe9a2a29fb54fa9169cd1"
   version = "v1.20.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:6ef14be530be39b6b9d75d54ce1d546ae9231e652d9e3eef198cbb19ce8ed3e7"
   name = "golang.org/x/crypto"
   packages = ["ssh/terminal"]
+  pruneopts = ""
   revision = "a49355c7e3f8fe157a85be2f77e6e269a0f89602"
 
 [[projects]]
   branch = "master"
+  digest = "1:7a2d59e5fc661ccf4ae7dc301c1a7332ec59b2ee435f78aa3eaa65cacb256370"
   name = "golang.org/x/net"
   packages = ["idna"]
+  pruneopts = ""
   revision = "d0887baf81f4598189d4e12a37c6da86f0bba4d0"
 
 [[projects]]
   branch = "master"
+  digest = "1:19f072f12708aaafef9064b49432953e3f813a98fcb356b30831cf2b0f5272b3"
   name = "golang.org/x/sys"
   packages = [
     "unix",
-    "windows"
+    "windows",
   ]
+  pruneopts = ""
   revision = "1b2967e3c290b7c545b3db0deeda16e9be4f98a2"
 
 [[projects]]
+  digest = "1:5acd3512b047305d49e8763eef7ba423901e85d5dd2fd1e71778a0ea8de10bd4"
   name = "golang.org/x/text"
   packages = [
     "collate",
@@ -156,20 +195,42 @@
     "unicode/bidi",
     "unicode/cldr",
     "unicode/norm",
-    "unicode/rangetable"
+    "unicode/rangetable",
   ]
+  pruneopts = ""
   revision = "f21a4dfb5e38f5895301dc265a8def02365cc3d0"
   version = "v0.3.0"
 
 [[projects]]
+  branch = "v2"
+  digest = "1:f0620375dd1f6251d9973b5f2596228cc8042e887cd7f827e4220bc1ce8c30e2"
   name = "gopkg.in/yaml.v2"
   packages = ["."]
+  pruneopts = ""
   revision = "5420a8b6744d3b0345ab293f6fcba19c978f1183"
-  version = "v2.2.1"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "1ff4e02c38d242f65262210414bcf60841615d7af0ab8dc2ccbd20c47a49308b"
+  input-imports = [
+    "github.com/activecm/mgorus",
+    "github.com/activecm/mgosec",
+    "github.com/activecm/rita-bl",
+    "github.com/activecm/rita-bl/database",
+    "github.com/activecm/rita-bl/list",
+    "github.com/activecm/rita-bl/sources/lists",
+    "github.com/activecm/rita-bl/sources/rpc",
+    "github.com/blang/semver",
+    "github.com/globalsign/mgo",
+    "github.com/globalsign/mgo/bson",
+    "github.com/olekukonko/tablewriter",
+    "github.com/rifflock/lfshook",
+    "github.com/sirupsen/logrus",
+    "github.com/skratchdot/open-golang/open",
+    "github.com/stretchr/testify/assert",
+    "github.com/stretchr/testify/require",
+    "github.com/urfave/cli",
+    "gopkg.in/yaml.v2",
+  ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/commands/analyze.go
+++ b/commands/analyze.go
@@ -45,7 +45,7 @@ func analyze(inDb string, configFile string) error {
 	// Check to see if we want to run a full database or just one off the command line
 	if inDb == "" {
 		res.Log.Info("Running analysis against all databases")
-		toRunDirty = append(toRun, res.MetaDB.GetUnAnalyzedDatabases()...)
+		toRunDirty = append(toRun, res.MetaDB.GetAnalyzeReadyDatabases()...)
 	} else {
 		toRunDirty = append(toRun, inDb)
 	}
@@ -55,6 +55,12 @@ func analyze(inDb string, configFile string) error {
 		info, err := res.MetaDB.GetDBMetaInfo(possDB)
 		if err != nil {
 			errStr := fmt.Sprintf("Error: %s not found.", possDB)
+			res.Log.Errorf(errStr)
+			fmt.Println(errStr)
+			continue
+		}
+		if !info.ImportFinished {
+			errStr := fmt.Sprintf("Error: %s hasn't finished being imported.", possDB)
 			res.Log.Errorf(errStr)
 			fmt.Println(errStr)
 			continue

--- a/database/meta_test.go
+++ b/database/meta_test.go
@@ -1,0 +1,39 @@
+package database
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMigrateDBMetaInfo(t *testing.T) {
+	type migrationTest struct {
+		in  DBMetaInfo
+		out DBMetaInfo
+	}
+
+	dbMetaInfos := []migrationTest{
+		migrationTest{
+			DBMetaInfo{
+				Name:           "Before ImportFinished Was Introduced In v1.1.0",
+				ImportFinished: false,
+				Analyzed:       false,
+				ImportVersion:  "v1.0.99",
+				AnalyzeVersion: "v1.0.99",
+			},
+			DBMetaInfo{
+				Name:           "Before ImportFinished Was Introduced In v1.1.0",
+				ImportFinished: true,
+				Analyzed:       false,
+				ImportVersion:  "v1.0.99",
+				AnalyzeVersion: "v1.0.99",
+			},
+		},
+	}
+
+	for _, testCase := range dbMetaInfos {
+		output, err := migrateDBMetaInfo(testCase.in)
+		require.Nil(t, err)
+		require.Equal(t, testCase.out, output)
+	}
+}

--- a/parser/mongodatastore.go
+++ b/parser/mongodatastore.go
@@ -118,13 +118,10 @@ func (mongo *MongoDatastore) Index() {
 		}
 		collMap.rwLock.Unlock()
 
-		err := mongo.metaDB.MarkDBImported(database, true)
-		if err != nil {
-			mongo.logger.WithFields(log.Fields{
-				"database": database,
-				"error":    err.Error(),
-			}).Error("Failed to mark import of database as finished")
-		}
+		//swallow err as err is logged in metadb
+		//the current code cannot recover from this error without
+		//a bit of a rewrite
+		mongo.metaDB.MarkDBImported(database, true)
 	}
 	mongo.writeMap.rwLock.Unlock()
 }


### PR DESCRIPTION
See PR #258. This PR follows up on the comment [here](https://github.com/activecm/rita/pull/258#issuecomment-428366524) by introducing the runDBInfoQuery method to ensure the data migration happens across all MetaDB database methods. 