### PR TITLE
fixed show databases issue

### DIFF
--- a/commands/show-databases.go
+++ b/commands/show-databases.go
@@ -10,8 +10,9 @@ import (
 func init() {
 
 	databases := cli.Command{
-		Name:  "show-databases",
-		Usage: "Print the databases currently stored",
+		Name:    "list",
+		Aliases: []string{"show-databases"},
+		Usage:   "Print the databases currently stored",
 		Flags: []cli.Flag{
 			configFlag,
 		},


### PR DESCRIPTION
A recent change attempted to use the same runDBMetaInfoQuery() function for everything in databases/meta.go, including this one where nil was passed in for the query. The issue with that is that the function then proceeded to try to update stuff as needed for the other callers of the function
that would error out and then return nothing in certain cases. 
