### PR TITLE
Implement default config values

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,24 +2,19 @@
 
 
 [[projects]]
-  digest = "1:5a71fb24ce7cbabaa4e30999bbc93e660ddd843af391b8719fb0d2faf0f81901"
   name = "github.com/activecm/mgorus"
   packages = ["."]
-  pruneopts = ""
   revision = "14fb55db664fcb78819379c2fcc01f917d682c67"
   version = "v0.1.1"
 
 [[projects]]
-  digest = "1:df541133b5b4919a9f1a215283caeaaa24cb4b58bc7358c97b970e7baf930391"
   name = "github.com/activecm/mgosec"
   packages = ["."]
-  pruneopts = ""
   revision = "3940290cb0e63eafbbabeb8c4a0a788f80e6bc7d"
   version = "v0.1.1"
 
 [[projects]]
   branch = "master"
-  digest = "1:150cbde83fd4a0c2620001ce4b2ec6bfc102321e7636c260c25ad66c9e4aa933"
   name = "github.com/activecm/rita-bl"
   packages = [
     ".",
@@ -27,183 +22,149 @@
     "list",
     "sources/lists",
     "sources/lists/util",
-    "sources/rpc",
+    "sources/rpc"
   ]
-  pruneopts = ""
   revision = "c067dd0a13599f118564cb3f6f022c94aef822ac"
 
 [[projects]]
-  digest = "1:79421244ba5848aae4b0a5c41e633a04e4894cb0b164a219dc8c15ec7facb7f1"
   name = "github.com/blang/semver"
   packages = ["."]
-  pruneopts = ""
   revision = "2ee87856327ba09384cabd113bc6b5d174e9ec0f"
   version = "v3.5.1"
 
 [[projects]]
-  digest = "1:0deddd908b6b4b768cfc272c16ee61e7088a60f7fe2f06c547bd3d8e1f8b8e77"
+  name = "github.com/creasty/defaults"
+  packages = ["."]
+  revision = "a7e48e2230891fc7456c8ab918c424c5b06c3192"
+  version = "v1.2.1"
+
+[[projects]]
   name = "github.com/davecgh/go-spew"
   packages = ["spew"]
-  pruneopts = ""
   revision = "8991bc29aa16c548c550c7ff78260e27b9ab7c73"
   version = "v1.1.1"
 
 [[projects]]
   branch = "master"
-  digest = "1:e9ffb9315dce0051beb757d0f0fc25db57c4da654efc4eada4ea109c2d9da815"
   name = "github.com/globalsign/mgo"
   packages = [
     ".",
     "bson",
     "internal/json",
     "internal/sasl",
-    "internal/scram",
+    "internal/scram"
   ]
-  pruneopts = ""
   revision = "eeefdecb41b842af6dc652aaea4026e8403e62df"
 
 [[projects]]
-  digest = "1:3dd078fda7500c341bc26cfbc6c6a34614f295a2457149fc1045cab767cbcf18"
   name = "github.com/golang/protobuf"
   packages = [
     "proto",
-    "ptypes/duration",
+    "ptypes/duration"
   ]
-  pruneopts = ""
   revision = "aa810b61a9c79d51363740d207bb46cf8e620ed5"
   version = "v1.2.0"
 
 [[projects]]
-  digest = "1:4f646745e87604d6ac39bd2a96b3c2f4a898d1866069fff26b8281d6f84b919e"
   name = "github.com/google/go-github"
   packages = ["github"]
-  pruneopts = ""
-  revision = "f55b50f38167644bb7e4be03d9a2bde71d435239"
-  version = "v18.2.0"
+  revision = "35781f7f4db7b3d7fc3359527472838da65023c6"
+  version = "v19.1.0"
 
 [[projects]]
-  digest = "1:cea4aa2038169ee558bf507d5ea02c94ca85bcca28a4c7bb99fd59b31e43a686"
   name = "github.com/google/go-querystring"
   packages = ["query"]
-  pruneopts = ""
   revision = "44c6ddd0a2342c386950e880b658017258da92fc"
   version = "v1.0.0"
 
 [[projects]]
   branch = "master"
-  digest = "1:7453365fbe13392fa8d3e893d62b8e8dff70c19b979c45ffaf54a7e6b6ec7064"
   name = "github.com/google/safebrowsing"
   packages = [
     ".",
-    "internal/safebrowsing_proto",
+    "internal/safebrowsing_proto"
   ]
-  pruneopts = ""
   revision = "456c2058968cdccc138b8ec0b27a76114fe82ce7"
 
 [[projects]]
-  digest = "1:6a874e3ddfb9db2b42bd8c85b6875407c702fa868eed20634ff489bc896ccfd3"
   name = "github.com/konsorten/go-windows-terminal-sequences"
   packages = ["."]
-  pruneopts = ""
   revision = "5c8c8bd35d3832f5d134ae1e1e375b69a4d25242"
   version = "v1.0.1"
 
 [[projects]]
-  digest = "1:82b912465c1da0668582a7d1117339c278e786c2536b3c3623029a0c7141c2d0"
   name = "github.com/mattn/go-runewidth"
   packages = ["."]
-  pruneopts = ""
   revision = "ce7b0b5c7b45a81508558cd1dba6bb1e4ddb51bb"
   version = "v0.0.3"
 
 [[projects]]
   branch = "master"
-  digest = "1:171c1337a8ad95624633b9a66fe318b4a1de286440c7efccdc21c86c773674ad"
   name = "github.com/olekukonko/tablewriter"
   packages = ["."]
-  pruneopts = ""
-  revision = "be2c049b30ccd4d3fd795d6bf7dce74e42eeedaa"
+  revision = "e6d60cf7ba1f42d86d54cdf5508611c4aafb3970"
 
 [[projects]]
-  digest = "1:256484dbbcd271f9ecebc6795b2df8cad4c458dd0f5fd82a8c2fa0c29f233411"
   name = "github.com/pmezard/go-difflib"
   packages = ["difflib"]
-  pruneopts = ""
   revision = "792786c7400a136282c1664665ae0a8db921c6c2"
   version = "v1.0.0"
 
 [[projects]]
-  digest = "1:463cf5034cda51cdb4ce56d317c1c1343be898c2bb5e576666394d53f4ba28cd"
   name = "github.com/rifflock/lfshook"
   packages = ["."]
-  pruneopts = ""
   revision = "b9218ef580f59a2e72dad1aa33d660150445d05a"
   version = "v2.4"
 
 [[projects]]
-  digest = "1:5f48b818f16848d05cf74f4cbdd0cbe9e0dcddb3c459b4c510c6e2c8e1b4dff1"
   name = "github.com/sirupsen/logrus"
   packages = ["."]
-  pruneopts = ""
-  revision = "ad15b42461921f1fb3529b058c6786c6a45d5162"
-  version = "v1.1.1"
+  revision = "bcd833dfe83d3cebad139e4a29ed79cb2318bf95"
+  version = "v1.2.0"
 
 [[projects]]
   branch = "master"
-  digest = "1:50b5be512f924d289f20e8b2aef8951d98b9bd8c44666cf169514906df597a4c"
   name = "github.com/skratchdot/open-golang"
   packages = ["open"]
-  pruneopts = ""
   revision = "75fb7ed4208cf72d323d7d02fd1a5964a7a9073c"
 
 [[projects]]
-  digest = "1:c587772fb8ad29ad4db67575dad25ba17a51f072ff18a22b4f0257a4d9c24f75"
   name = "github.com/stretchr/testify"
   packages = [
     "assert",
-    "require",
+    "require"
   ]
-  pruneopts = ""
   revision = "f35b8ab0b5a2cef36673838d662e249dd9c94686"
   version = "v1.2.2"
 
 [[projects]]
-  digest = "1:e85837cb04b78f61688c6eba93ea9d14f60d611e2aaf8319999b1a60d2dafbfa"
   name = "github.com/urfave/cli"
   packages = ["."]
-  pruneopts = ""
   revision = "cfb38830724cc34fedffe9a2a29fb54fa9169cd1"
   version = "v1.20.0"
 
 [[projects]]
   branch = "master"
-  digest = "1:78f41d38365ccef743e54ed854a2faf73313ba0750c621116a8eeb0395590bd0"
   name = "golang.org/x/crypto"
   packages = ["ssh/terminal"]
-  pruneopts = ""
-  revision = "0c41d7ab0a0ee717d4590a44bcb987dfd9e183eb"
+  revision = "505ab145d0a99da450461ae2c1a9f6cd10d1f447"
 
 [[projects]]
   branch = "master"
-  digest = "1:6543c75ddc1efc0041202dd49378ee2e5711b7cc82c2845c0437eef6276cc984"
   name = "golang.org/x/net"
   packages = ["idna"]
-  pruneopts = ""
-  revision = "04a2e542c03f1d053ab3e4d6e5abcd4b66e2be8e"
+  revision = "351d144fa1fc0bd934e2408202be0c29f25e35a0"
 
 [[projects]]
   branch = "master"
-  digest = "1:03a1b1f2bfb0a6b2291c4161032429b1e8a1f23cc68530ad64358f8b493ead5f"
   name = "golang.org/x/sys"
   packages = [
     "unix",
-    "windows",
+    "windows"
   ]
-  pruneopts = ""
-  revision = "8a28ead16f52c8aaeffbf79239b251dfdf6c4f96"
+  revision = "70b957f3b65e069b4930ea94e2721eefa0f8f695"
 
 [[projects]]
-  digest = "1:5acd3512b047305d49e8763eef7ba423901e85d5dd2fd1e71778a0ea8de10bd4"
   name = "golang.org/x/text"
   packages = [
     "collate",
@@ -219,42 +180,20 @@
     "unicode/bidi",
     "unicode/cldr",
     "unicode/norm",
-    "unicode/rangetable",
+    "unicode/rangetable"
   ]
-  pruneopts = ""
   revision = "f21a4dfb5e38f5895301dc265a8def02365cc3d0"
   version = "v0.3.0"
 
 [[projects]]
   branch = "v2"
-  digest = "1:f0620375dd1f6251d9973b5f2596228cc8042e887cd7f827e4220bc1ce8c30e2"
   name = "gopkg.in/yaml.v2"
   packages = ["."]
-  pruneopts = ""
-  revision = "5420a8b6744d3b0345ab293f6fcba19c978f1183"
+  revision = "51d6538a90f86fe93ac480b35f37b2be17fef232"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  input-imports = [
-    "github.com/activecm/mgorus",
-    "github.com/activecm/mgosec",
-    "github.com/activecm/rita-bl",
-    "github.com/activecm/rita-bl/database",
-    "github.com/activecm/rita-bl/list",
-    "github.com/activecm/rita-bl/sources/lists",
-    "github.com/blang/semver",
-    "github.com/globalsign/mgo",
-    "github.com/globalsign/mgo/bson",
-    "github.com/google/go-github/github",
-    "github.com/olekukonko/tablewriter",
-    "github.com/rifflock/lfshook",
-    "github.com/sirupsen/logrus",
-    "github.com/skratchdot/open-golang/open",
-    "github.com/stretchr/testify/assert",
-    "github.com/stretchr/testify/require",
-    "github.com/urfave/cli",
-    "gopkg.in/yaml.v2",
-  ]
+  inputs-digest = "5a94a3d0e192f3f23c1af7ac7b323e4bfec54067bbdae161c3e4b62383f2914f"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -59,3 +59,7 @@
 [[constraint]]
   branch = "v2"
   name = "gopkg.in/yaml.v2"
+
+[[constraint]]
+  name = "github.com/creasty/defaults"
+  version = "1.2.1"

--- a/commands/test-config.go
+++ b/commands/test-config.go
@@ -33,8 +33,8 @@ func testConfiguration(c *cli.Context) error {
 	// First, print out the config as it was parsed
 	conf, err := config.LoadConfig(c.String("config"))
 	if err != nil {
-		fmt.Fprintf(os.Stdout, "Failed to config, exiting")
-		panic(err)
+		fmt.Fprintf(os.Stdout, "Failed to config: %s\n", err.Error())
+		os.Exit(-1)
 	}
 
 	staticConfig, err := yaml.Marshal(conf.S)

--- a/commands/update-check.go
+++ b/commands/update-check.go
@@ -30,17 +30,10 @@ func GetVersionPrinter() func(*cli.Context) {
 //returns a string indicating the new version if available
 func updateCheck(configFile string) string {
 	res := resources.InitResources(configFile)
-	deltaPtr := res.Config.S.UserConfig.UpdateCheckFrequency
+	delta := res.Config.S.UserConfig.UpdateCheckFrequency
 	var newVersion semver.Version
 	var err error
-	var delta int
 	var timestamp time.Time
-
-	if deltaPtr == nil {
-		delta = 14
-	} else {
-		delta = *deltaPtr
-	}
 
 	if delta <= 0 {
 		return ""
@@ -108,7 +101,6 @@ func getRemoteVersion() (semver.Version, error) {
 // The return value is printed regardless so, "" is returned on errror.
 //func informUser( verStr string, index int ) string {
 func informUser(local semver.Version, remote semver.Version) string {
-
 	return fmt.Sprintf(informFmtStr,
 		versions[versionDiffIndex(remote, local)],
 		fmt.Sprint(remote))

--- a/config/static.go
+++ b/config/static.go
@@ -71,7 +71,7 @@ type (
 
 	//BeaconStaticCfg is used to control the beaconing analysis module
 	BeaconStaticCfg struct {
-		DefaultConnectionThresh int `yaml:"DefaultConnectionThresh" default:"24"`
+		DefaultConnectionThresh int `yaml:"DefaultConnectionThresh" default:"20"`
 	}
 
 	//FilteringStaticCfg controls address filtering

--- a/config/static_test.go
+++ b/config/static_test.go
@@ -35,9 +35,8 @@ BlackListed:
 Beacon:
     DefaultConnectionThresh: 24
 Filtering:
-    AlwaysInclude: ["8.8.8.8/32"]
-    InternalSubnets: ["10.0.0.0/8","172.16.0.0/12","192.168.0.0/16"]
-
+    AlwaysInclude: [8.8.8.8/32]
+    InternalSubnets: [10.0.0.0/8,172.16.0.0/12,192.168.0.0/16]
 `
 
 var testConfigFullExp = StaticCfg{
@@ -79,14 +78,22 @@ var testConfigFullExp = StaticCfg{
 	},
 }
 
+// TestParseStaticConfig ensures that a yaml config
+// string is correctly converted into a StaticCfg struct.
 func TestParseStaticConfig(t *testing.T) {
-	config, err := parseStaticConfig([]byte(staticConfigParserTestConfig))
+	config := &StaticCfg{}
+	err := parseStaticConfig([]byte(staticConfigParserTestConfig), config)
+
+	// We are not testing the version setting ensure they are equal
 	testConfigFullExp.Version = config.Version
 	testConfigFullExp.ExactVersion = config.ExactVersion
+
 	assert.Nil(t, err)
 	assert.Equal(t, *config, testConfigFullExp)
 }
 
+// TestFilePathCleaning ensures that paths specified
+// in a config file are cleaned up correctly.
 func TestFilePathCleaning(t *testing.T) {
 	testConfig := `
 LogConfig:
@@ -102,9 +109,13 @@ Bro:
 			ImportDirectory: "/opt/bro/logs",
 		},
 	}
-	config, err := parseStaticConfig([]byte(testConfig))
+	config := &StaticCfg{}
+	err := parseStaticConfig([]byte(testConfig), config)
+
+	// We are not testing the version setting ensure they are equal
 	testConfigExp.Version = config.Version
 	testConfigExp.ExactVersion = config.ExactVersion
+
 	assert.Nil(t, err)
 	assert.Equal(t, *config, testConfigExp)
 }

--- a/config/static_test.go
+++ b/config/static_test.go
@@ -26,6 +26,8 @@ Bro:
     DBRoot: "RITA"
     MetaDB: MetaDatabase
     ImportBuffer: 100000
+UserConfig:
+    UpdateCheckFrequency: 14
 BlackListed:
     myIP.ms: true
     MalwareDomains.com: true
@@ -61,6 +63,9 @@ var testConfigFullExp = StaticCfg{
 		DBRoot:          "RITA",
 		MetaDB:          "MetaDatabase",
 		ImportBuffer:    100000,
+	},
+	UserConfig: UserCfgStaticCfg{
+		UpdateCheckFrequency: 14,
 	},
 	Blacklisted: BlacklistedStaticCfg{
 		UseIPms:            true,

--- a/config/tables.go
+++ b/config/tables.go
@@ -14,82 +14,47 @@ type (
 
 	//LogTableCfg contains the configuration for logging
 	LogTableCfg struct {
-		RitaLogTable string
+		RitaLogTable string `default:"logs"`
 	}
 
 	//StructureTableCfg contains the names of the base level collections
 	StructureTableCfg struct {
-		ConnTable         string
-		HTTPTable         string
-		DNSTable          string
-		UniqueConnTable   string
-		HostTable         string
-		IPv4Table         string
-		IPv6Table         string
-		FrequentConnTable string
+		ConnTable         string `default:"conn"`
+		HTTPTable         string `default:"http"`
+		DNSTable          string `default:"dns"`
+		UniqueConnTable   string `default:"uconn"`
+		HostTable         string `default:"host"`
+		IPv4Table         string `default:"ipv4"`
+		IPv6Table         string `default:"ipv6"`
+		FrequentConnTable string `default:"freqConn"`
 	}
 
 	//BlacklistedTableCfg is used to control the blacklisted analysis module
 	BlacklistedTableCfg struct {
-		BlacklistDatabase string
-		SourceIPsTable    string
-		DestIPsTable      string
-		HostnamesTable    string
+		SourceIPsTable string `default:"blSourceIPs"`
+		DestIPsTable   string `default:"blDestIPs"`
+		HostnamesTable string `default:"blHostnames"`
 	}
 
 	//DNSTableCfg is used to control the dns analysis module
 	DNSTableCfg struct {
-		ExplodedDNSTable string
-		HostnamesTable   string
+		ExplodedDNSTable string `default:"explodedDns"`
+		HostnamesTable   string `default:"hostnames"`
 	}
 
 	//BeaconTableCfg is used to control the beaconing analysis module
 	BeaconTableCfg struct {
-		BeaconTable string
+		BeaconTable string `default:"beacon"`
 	}
 
 	//UserAgentTableCfg is used to control the useragent analysis module
 	UserAgentTableCfg struct {
-		UserAgentTable string
+		UserAgentTable string `default:"useragent"`
 	}
 
 	//MetaTableCfg contains the meta db collection names
 	MetaTableCfg struct {
-		FilesTable     string
-		DatabasesTable string
+		FilesTable     string `default:"files"`
+		DatabasesTable string `default:"databases"`
 	}
 )
-
-// loadTableConfig initializes a config struct
-func loadTableConfig() *TableCfg {
-	var config = new(TableCfg)
-
-	// initialize all the table configs
-	config.Log.RitaLogTable = "logs"
-
-	config.Structure.ConnTable = "conn"
-	config.Structure.HTTPTable = "http"
-	config.Structure.DNSTable = "dns"
-	config.Structure.UniqueConnTable = "uconn"
-	config.Structure.HostTable = "host"
-	config.Structure.IPv4Table = "ipv4"
-	config.Structure.IPv6Table = "ipv6"
-	config.Structure.FrequentConnTable = "freqConn"
-
-	config.Blacklisted.BlacklistDatabase = "rita-blacklist"
-	config.Blacklisted.SourceIPsTable = "blSourceIPs"
-	config.Blacklisted.DestIPsTable = "blDestIPs"
-	config.Blacklisted.HostnamesTable = "blHostnames"
-
-	config.DNS.ExplodedDNSTable = "explodedDns"
-	config.DNS.HostnamesTable = "hostnames"
-
-	config.Beacon.BeaconTable = "beacon"
-
-	config.UserAgent.UserAgentTable = "useragent"
-
-	config.Meta.FilesTable = "files"
-	config.Meta.DatabasesTable = "databases"
-
-	return config
-}

--- a/config/testing.go
+++ b/config/testing.go
@@ -1,5 +1,9 @@
 package config
 
+import (
+	"github.com/creasty/defaults"
+)
+
 const testConfig = `
 MongoDB:
     ConnectionString: null
@@ -34,24 +38,32 @@ Filtering:
 
 // LoadTestingConfig loads the hard coded testing config
 func LoadTestingConfig(mongoURI string) (*Config, error) {
-	Version = "v0.0.0+testing"
-	ExactVersion = "v0.0.0+testing"
-	var config = new(Config)
-	static, err := parseStaticConfig([]byte(testConfig))
-	if err != nil {
-		return config, err
+	config := &Config{}
+
+	// Initialize table config to the default values
+	if err := defaults.Set(&config.T); err != nil {
+		return nil, err
 	}
-	config.S = *static
+
+	// Initialize static config to the default values
+	if err := defaults.Set(&config.S); err != nil {
+		return nil, err
+	}
 
 	config.S.MongoDB.ConnectionString = mongoURI
 
-	config.T = *loadTableConfig()
-
-	running, err := loadRunningConfig(static)
-	if err != nil {
-		return config, err
+	// Deserialize the yaml file contents into the static config
+	if err := parseStaticConfig([]byte(testConfig), &config.S); err != nil {
+		return nil, err
 	}
-	config.R = *running
+
+	config.S.Version = "v0.0.0+testing"
+	config.S.ExactVersion = "v0.0.0+testing"
+
+	// Use the static config to initialize the running config
+	if err := initRunningConfig(&config.S, &config.R); err != nil {
+		return nil, err
+	}
 
 	return config, nil
 }


### PR DESCRIPTION
This pull request gives default values to every member of the config struct. This allows us to gracefully handle older /etc/rita/config.yaml files. If a section or value is missing we can just define a sane default, which is what most people's config files would contain anyway.  And a user can always override defaults with their config file.

This change allows us to add new fields without worrying about migrating a user's previous config file. These pull requests will immediately benefit from this change.
- https://github.com/activecm/rita/pull/311
- https://github.com/activecm/rita/pull/310
- https://github.com/activecm/rita/pull/328