### PR TITLE
Fixes #266: Create config options for modules

### DIFF
--- a/commands/analyze.go
+++ b/commands/analyze.go
@@ -141,31 +141,42 @@ func analyze(inDb string, res *resources.Resources, resetFlag bool) error {
 		logAnalysisFunc("Unique Connections", td, res,
 			structure.BuildUniqueConnectionsCollection,
 		)
-		// must go after uconns
-		logAnalysisFunc("Beaconing", td, res,
-			beacon.BuildBeaconCollection,
-		)
+
+		if res.Config.S.Beacon.Enabled {
+			// must go after uconns
+			logAnalysisFunc("Beaconing", td, res,
+				beacon.BuildBeaconCollection,
+			)
+		}
+
 		// must go after beaconing
 		logAnalysisFunc("Unique Hosts", td, res,
 			func(innerRes *resources.Resources) {
 				structure.BuildHostsCollection(innerRes)
 			},
 		)
-		logAnalysisFunc("Unique Hostnames", td, res,
-			dns.BuildHostnamesCollection,
-		)
 
-		logAnalysisFunc("Exploded DNS", td, res,
-			dns.BuildExplodedDNSCollection,
-		)
+		if res.Config.S.DNS.Enabled {
+			logAnalysisFunc("Unique Hostnames", td, res,
+				dns.BuildHostnamesCollection,
+			)
 
-		logAnalysisFunc("User Agent", td, res,
-			useragent.BuildUserAgentCollection,
-		)
+			logAnalysisFunc("Exploded DNS", td, res,
+				dns.BuildExplodedDNSCollection,
+			)
+		}
 
-		logAnalysisFunc("Blacklisted", td, res,
-			blacklist.BuildBlacklistedCollections,
-		)
+		if res.Config.S.UserAgent.Enabled {
+			logAnalysisFunc("User Agent", td, res,
+				useragent.BuildUserAgentCollection,
+			)
+		}
+
+		if res.Config.S.Blacklisted.Enabled {
+			logAnalysisFunc("Blacklisted", td, res,
+				blacklist.BuildBlacklistedCollections,
+			)
+		}
 
 		res.MetaDB.MarkDBAnalyzed(td, true)
 		endIndiv := time.Now()

--- a/config/static.go
+++ b/config/static.go
@@ -18,6 +18,8 @@ type (
 		Log          LogStaticCfg         `yaml:"LogConfig"`
 		Blacklisted  BlacklistedStaticCfg `yaml:"BlackListed"`
 		Beacon       BeaconStaticCfg      `yaml:"Beacon"`
+		DNS          DNSStaticCfg         `yaml:"DNS"`
+		UserAgent    UserAgentStaticCfg   `yaml:"UserAgent"`
 		Bro          BroStaticCfg         `yaml:"Bro"`
 		Filtering    FilteringStaticCfg   `yaml:"Filtering"`
 		Strobe       StrobeStaticCfg      `yaml:"Strobe"`
@@ -63,6 +65,7 @@ type (
 
 	//BlacklistedStaticCfg is used to control the blacklisted analysis module
 	BlacklistedStaticCfg struct {
+		Enabled            bool     `yaml:"Enabled" default:"true"`
 		UseIPms            bool     `yaml:"myIP.ms" default:"true"`
 		UseDNSBH           bool     `yaml:"MalwareDomains.com" default:"true"`
 		UseMDL             bool     `yaml:"MalwareDomainList.com" default:"true"`
@@ -73,7 +76,18 @@ type (
 
 	//BeaconStaticCfg is used to control the beaconing analysis module
 	BeaconStaticCfg struct {
-		DefaultConnectionThresh int `yaml:"DefaultConnectionThresh" default:"20"`
+		Enabled                 bool `yaml:"Enabled" default:"true"`
+		DefaultConnectionThresh int  `yaml:"DefaultConnectionThresh" default:"20"`
+	}
+
+	//DNSStaticCfg is used to control the DNS analysis module
+	DNSStaticCfg struct {
+		Enabled bool `yaml:"Enabled" default:"true"`
+	}
+
+	//UserAgentStaticCfg is used to control the User Agent analysis module
+	UserAgentStaticCfg struct {
+		Enabled bool `yaml:"Enabled" default:"true"`
 	}
 
 	//FilteringStaticCfg controls address filtering

--- a/etc/rita.yaml
+++ b/etc/rita.yaml
@@ -93,6 +93,7 @@ Filtering:
     #  - 192.168.0.0/16      # Private-Use Networks  RFC 1918
 
 BlackListed:
+    Enabled: true
     # These are blacklists built into rita-blacklist. Set these to false
     # to disable checks against them.
     myIP.ms: true
@@ -118,6 +119,7 @@ BlackListed:
     CustomHostnameBlacklists: []
 
 Beacon:
+    Enabled: true
     # The default minimum number of connections used for beacons analysis.
     # Any two hosts connecting fewer than this number will not be analyzed.
     # 20 was chosen as it is a little bit less than once per hour in a day,
@@ -128,6 +130,12 @@ Beacon:
     # increase this value to improve performance if you are not concerned
     # about slow beacons.
     DefaultConnectionThresh: 20
+
+DNS:
+    Enabled: true
+
+UserAgent:
+    Enabled: true
 
 Strobe:
     # This sets the maximum number of connections between any two given hosts that are stored.


### PR DESCRIPTION
Adds Config options that allow user to not use modules during analysis.

It might be better if the modules themselves were in control of whether or not they run.
But then the logs would still be reporting on non-activated functions and resolving that problem seemed out of scope for this PR.

Closes #266 