### PR TITLE
Finished Logmover

### DIFF
--- a/logmover/Readme.md
+++ b/logmover/Readme.md
@@ -5,58 +5,60 @@ the scripts in this directory will help you automatically transfer the logs
 collected by Bro IDS/ Zeek to your RITA installation and kick off the
 RITA import and analysis process.
 
-The two scripts work with each other. [Watcher.sh](./watcher.sh) runs on the
+The two scripts work with each other. [log_watcher.bash](./log_watcher.bash) runs on the
 RITA system, waits for data to finish transferring in, and kicks off the
-import and analyze process. On the other hand, [logpush.bash](./logpush.bash)
+import and analyze process. On the other hand, [log_pusher.bash](./log_pusher.bash)
 runs on a Bro IDS/ Zeek system, transfers the previous day's logs to the
 RITA system, and lets the watcher script know when it finishes.
 
 Multiple instances of Bro IDS/ Zeek instances may be used with a single instance
-of RITA by running an instance of [logpush.bash](./logpush.bash) on each
+of RITA by running an instance of [log_pusher.bash](./log_pusher.bash) on each
 Bro IDS/ Zeek system.
+
+NOTE: [log_watcher.bash](./log_watcher.bash) deletes the received logs after they are
+imported. This prevents duplicating data archived on the Bro IDS/ Zeek collector.
 
 ## Installation
 
 1. Ensure that each system running Bro IDS/ Zeek is able to access the system running RITA over SSH using an SSH key that is not password protected.
-    - Remember the SSH connection details, we will need them later.
+    - Remember the SSH connection details, you will need them later.
         - RITA system hostname/ IP address
         - The name of the user account used to access the RITA system
         - The path to the SSH key used to access the RITA system
-1. Install [watcher.sh](./watcher.sh) on the RITA system
-    - Edit [watcher.sh](./watcher.sh)
-        - Set `LOG_DIR` to the directory you intend to keep your Bro logs in on the RITA system
+1. Install [log_watcher.bash](./log_watcher.bash) on the RITA system
+    - Edit [log_watcher.bash](./log_watcher.bash)
+        - Set `LOG_DIR` to the directory RITA is set to read Bro logs from
     - Copy the edited script to the RITA system
-        - This guide assumes the watcher script is placed at `/usr/local/bin/watcher.sh`
+        - This guide assumes the watcher script is placed at `/usr/local/bin/log_watcher.bash`
     - Ensure the script is executable
-        - `sudo chmod 755 /usr/local/bin/watcher.sh`
+        - `sudo chmod 755 /usr/local/bin/log_watcher.bash`
     - If the script is placed in `/usr/local/bin`, ensure `root` owns the script
-        - `sudo chown root:root /usr/local/bin/watcher.sh`
+        - `sudo chown root:root /usr/local/bin/log_watcher.bash`
     - Ensure the directory referenced by `LOG_DIR` exists on the RITA system
     - As the user noted above, run `crontab -e`
-        - This guide sets [watcher.sh](./watcher.sh) to run at 12:10 a.m.
-        - Add `10 0 * * * /usr/local/bin/watcher.sh` to the end of the user's crontab
-1. Install [logpush.bash](./logpush.bash) on each Bro IDS/ Zeek System
-    - Edit [logpush.bash](./logpush.bash)
+        - This guide sets [log_watcher.bash](./log_watcher.bash) to run at 12:10 a.m.
+        - Add `10 0 * * * /usr/local/bin/log_watcher.bash` to the end of the user's crontab
+1. Install [log_pusher.bash](./log_pusher.bash) on each Bro IDS/ Zeek System
+    - Edit [log_pusher.bash](./log_pusher.bash)
         - Set `USER` to the name of the user account determined in the first step
         - Set `REMOTE` to the hostname/ IP address of the RITA system
         - Set `REMOTE_LOG_DIR` to the same value as `LOG_DIR` in the second step
         - Set `LOCAL_LOG_DIR` to the directory containing your Bro IDS/ Zeek logs
-        - Set `COLLECTOR` the name of this Bro IDS/ Zeek System. This will be used to name the RITA datasets which originate from this system.
+        - Set `COLLECTOR` to the name of this Bro IDS/ Zeek System. This will be used to name the RITA datasets which originate from this system.
         - Set `KEYFILE` to the path of the SSH key that will be used to connect to the RITA system
     - Copy the edited script to the Bro IDS/ Zeek system
-        - This guide assumes the watcher script is placed at `/usr/local/bin/logpush.bash`
+        - This guide assumes the watcher script is placed at `/usr/local/bin/log_pusher.bash`
     - Ensure the script is executable
-        - `sudo chmod 755 /usr/local/bin/logpush.bash`
+        - `sudo chmod 755 /usr/local/bin/log_pusher.bash`
     - If the script is placed in `/usr/local/bin`, ensure `root` owns the script
-        - `sudo chown root:root /usr/local/bin/logpush.bash`
+        - `sudo chown root:root /usr/local/bin/log_pusher.bash`
     - As a user with access to the Bro logs and SSH key, run `crontab -e`
-        - This guide sets [logpush.bash](./logpush.bash) to run at 12:05 a.m.
-        - It is important that [logpush.bash](./logpush.bash) runs before [watcher.sh](./watcher.sh). However, [logpush.bash](./logpush.bash) does *not* have to finish executing before [watcher.sh](./watcher.sh) runs.
-        - Add `5 0 * * * /usr/local/bin/logpush.bash` to the end of the user's crontab
+        - This guide sets [log_pusher.bash](./log_pusher.bash) to run at 12:05 a.m.
+        - It is important that [log_pusher.bash](./log_pusher.bash) runs before [log_watcher.bash](./log_watcher.bash). However, [log_pusher.bash](./log_pusher.bash) does *not* have to finish executing before [log_watcher.bash](./log_watcher.bash) runs.
+        - Add `5 0 * * * /usr/local/bin/log_pusher.bash` to the end of the user's crontab
 
 If all goes well, logs will be transferred from the Bro IDS/ Zeek box at 12:05 a.m. The watcher script will kick off at 12:10 a.m., wait for the transfers to finish, and begin analyzing the data.
 
-NOTE: There is a bug at the moment which requires [logpush.bash](./logpush.bash) to be able to create a file in the working directory. If [logpush.bash](./logpush.bash) is placed in `/usr/local/bin` the script must be ran as root. A patch will soon be available which will create the needed file in a `/tmp` directory.
 
-NOTE: [logpush.bash](./logpush.bash) and [watcher.sh](./watcher.sh) will not work if the directory referenced by
+NOTE: [log_pusher.bash](./log_pusher.bash) and [log_watcher.bash](./log_watcher.bash) will not work if the directory referenced by
 `LOG_DIR`/ `REMOTE_LOG_DIR` is stored within a NFS filesystem. NFS does not properly support `flock`.

--- a/logmover/log_pusher.bash
+++ b/logmover/log_pusher.bash
@@ -20,7 +20,7 @@ REMOTE_LOG_DIR=""
 LOCAL_LOG_DIR=""
 
 # The name of this collector node
-# The logs will be stored at REMOTE_LOG_DIR/COLLECTOR
+# The logs will be stored at REMOTE_LOG_DIR/YYYY-MM-DD-COLLECTOR
 COLLECTOR=""
 
 # The ssh key to connect to the RITA server with
@@ -34,7 +34,7 @@ KEYFILE=""
 LOCK="$REMOTE_LOG_DIR/.logpush.lock"
 
 # We will store the log data here
-DEST_DIR="$REMOTE_LOG_DIR/$COLLECTOR"
+DEST_DIR="$REMOTE_LOG_DIR/$(date -d "yesterday" +%Y-%m-%d)-$COLLECTOR"
 
 # We want to transfer yesterday's logs
 TX_DIR=$LOCAL_LOG_DIR/$(date -d "yesterday" +%Y-%m-%d)
@@ -66,4 +66,4 @@ fi
 
 # Send the logs
 echo "Sending $TX_DIR to $USER@$REMOTE:$DEST_DIR"
-rsync -a -e "ssh -i $KEYFILE" --rsync-path="$SERVER_SCRIPT" $TX_DIR $USER@$REMOTE:$DEST_DIR
+rsync -a -e "ssh -i $KEYFILE" --rsync-path="$SERVER_SCRIPT" $TX_DIR/ $USER@$REMOTE:$DEST_DIR

--- a/logmover/log_pusher.bash
+++ b/logmover/log_pusher.bash
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This script pushes logs to the RITA server
 # Put this in an unprivileged user's cron tab on

--- a/logmover/log_watcher.bash
+++ b/logmover/log_watcher.bash
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 # Run this script on the RITA host  after writes
 # have started coming into the analysis server
@@ -14,7 +14,7 @@ LOG_DIR=""
 LOCK_NAME=".logpush.lock"
 LOCK="$LOG_DIR/$LOCK_NAME"
 
-(
+{
   echo "Waiting for file transfers to finish"
   flock -x 9
   echo "Importing files into RITA"
@@ -23,7 +23,7 @@ LOCK="$LOG_DIR/$LOCK_NAME"
   # Remove the bro logs now that they have been imported.
   # Backups should remain on the collectors
   find $LOG_DIR ! -path $LOG_DIR ! -name $LOCK_NAME -exec rm -rf {} +
-) 9>$LOCK
+} 9>$LOCK
 
 echo "Analyzing imported files"
 rita analyze

--- a/logmover/logpush.bash
+++ b/logmover/logpush.bash
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 # This script pushes logs to the RITA server
-# Put this in an unprivileged user's cron tab on 
-# your bro nodes at some time around 1 am, 
+# Put this in an unprivileged user's cron tab on
+# your bro nodes at some time around 1 am,
 # ideally some time after bro has safely
 # archived yesterday's logs
 
@@ -27,9 +27,9 @@ COLLECTOR=""
 KEYFILE=""
 
 ##################################################
-# We use shared locks for writing to the server, 
+# We use shared locks for writing to the server,
 # and an exclusive lock for parsing
-# Note: distributed locking is hard, 
+# Note: distributed locking is hard,
 # so we use ssh to lock on the RITA server
 LOCK="$REMOTE_LOG_DIR/.rita.read.lock"
 
@@ -41,10 +41,12 @@ DEST_DIR="$REMOTE_LOG_DIR/$COLLECTOR"
 # SSH will exit gracefully
 SCRIPT='( flock -s 9; sleep infinity & echo $!; wait )9>'"$LOCK"
 
-# We need a temporary directory to hold the semaphore (lock pipe)
+# We need a temporary directory to hold the lock pipe
 LOGMOVER_TEMP_DIR="$(mktemp -d rita-logmover.XXXXXXXXXXXX)"
 
 # We use a named pipe to talk between threaded tasks
+# The LOCK_PIPE lets us know when we have established a shared
+# lock on the machine running watcher.sh.
 LOCK_PIPE="$LOGMOVER_TEMP_DIR/.lock_pipe"
 
 # We want to transfer yesterday's logs

--- a/logmover/watcher.sh
+++ b/logmover/watcher.sh
@@ -5,24 +5,25 @@
 # from the bro nodes. If you start the logpush
 # script at 1 am on the nodes, start this script
 # at about 1:15 or 2 am. As long as the logpush
-# has been run before this script, all will be well. 
+# has been run before this script, all will be well.
 
 # Where RITA is configured to read bro logs from
 LOG_DIR=""
 
 ##################################################
-LOCK_NAME=".rita.read.lock"
+LOCK_NAME=".logpush.lock"
 LOCK="$LOG_DIR/$LOCK_NAME"
 
 (
-  echo "Waiting for exclusive lock"
+  echo "Waiting for file transfers to finish"
   flock -x 9
-  echo "Gained exclusive lock"
-  echo "Parsing"
-  find $LOG_DIR -name *.gz -exec gzip -d {} \;
+  echo "Importing files into RITA"
   rita import
+
+  # Remove the bro logs now that they have been imported.
+  # Backups should remain on the collectors
   find $LOG_DIR ! -path $LOG_DIR ! -name $LOCK_NAME -exec rm -rf {} +
-  echo "Finished parsing"
 ) 9>$LOCK
-echo "Analyzing"
+
+echo "Analyzing imported files"
 rita analyze


### PR DESCRIPTION
This PR build upon the previous logmover work. 
`logpush.bash` has been renamed and reworked in `log_pusher.bash`
`watcher.sh` has been renamed to `log_watcher.bash`

`logpush.bash` has been dramatically simplified using rsync's `--rsync-path` option. This option allows you to specify a script which will run the server side rsync daemon. Normally this script is simply `rsync`. However, I've taken advantage of this option to run the file locking procedure. Previously, we opened up a second ssh session to handle the file locking which created a bit of a mess. The pipe that needed to be moved to /tmp was a part of this mess. (As mentioned at the bottom of the old README)

This PR has been tested by allowing ssh access to my local machine and running multiple instances of `log_pusher.bash` followed by an instance of `log_watcher.bash`. Everything seemed to work fine. 