### PR TITLE
re-enable writing to conns for long conns module

### DIFF
--- a/parser/fsimporter.go
+++ b/parser/fsimporter.go
@@ -375,11 +375,11 @@ func (fs *FSImporter) parseFiles(indexedFiles []*fpt.IndexedFile, parsingThreads
 
 								// stores the conn record in conn collection if below threshold
 								if connCount < fs.connLimit {
-									// datastore.Store(&ImportedData{
-									// 	BroData:          data,
-									// 	TargetDatabase:   fs.res.DB.GetSelectedDB(),
-									// 	TargetCollection: targetCollection,
-									// })
+									datastore.Store(&ImportedData{
+										BroData:          data,
+										TargetDatabase:   fs.res.DB.GetSelectedDB(),
+										TargetCollection: targetCollection,
+									})
 								}
 							}
 


### PR DESCRIPTION
re-enabling writing out conns logs to mongo due to long conns module