### PR TITLE
Fix Invalid Certificate Output Text

### DIFF
--- a/pkg/certificate/mongodb.go
+++ b/pkg/certificate/mongodb.go
@@ -76,7 +76,7 @@ func (r *repo) Upsert(certMap map[string]*Input) {
 	p := mpb.New(mpb.WithWidth(20))
 	bar := p.AddBar(int64(len(certMap)),
 		mpb.PrependDecorators(
-			decor.Name("\t[-] UserAgent Analysis:", decor.WC{W: 30, C: decor.DidentRight}),
+			decor.Name("\t[-] Invalid Cert Analysis:", decor.WC{W: 30, C: decor.DidentRight}),
 			decor.CountersNoUnit(" %d / %d ", decor.WCSyncWidth),
 		),
 		mpb.AppendDecorators(decor.Percentage()),


### PR DESCRIPTION
This PR fixes a bug that resulted in UserAgent Analysis appearing twice in the analysis output.
The invalid certificate analysis was writing an incorrect title out to the screen.

Before:
```
	[-] Host Analysis:            4809 / 4809  [==================] 100 %
	[-] Uconn Analysis:           16123 / 16123  [==================] 100 %
	[-] Exploded DNS Analysis:    3683 / 3683  [==================] 100 %
	[-] Hostname Analysis:        3683 / 3683  [==================] 100 %
	[-] Beacon Analysis:          16123 / 16123  [==================] 100 %
	[-] UserAgent Analysis:       16 / 16  [==================] 100 %
	[-] UserAgent Analysis:       41 / 41  [==================] 100 %
```

After:
```
	[-] Host Analysis:            4809 / 4809  [==================] 100 %
	[-] Uconn Analysis:           16123 / 16123  [==================] 100 %
	[-] Exploded DNS Analysis:    3683 / 3683  [==================] 100 %
	[-] Hostname Analysis:        3683 / 3683  [==================] 100 %
	[-] Beacon Analysis:          16123 / 16123  [==================] 100 %
	[-] UserAgent Analysis:       16 / 16  [==================] 100 %
	[-] Invalid Cert Analysis:    41 / 41  [==================] 100 %
```