### PR TITLE
417 fix v3 db delete

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -62,7 +62,7 @@ Note that any value listed in the `Filtering` section should be in CIDR format. 
       * `rita import path/to/your/bro_logs/ database_name`
     * **Option 2**: Set up the Bro configuration in `/etc/rita/config.yaml` for repeated imports
       * Set `ImportDirectory` to the `path/to/your/bro_logs`. The default is `/opt/bro/logs`
-      * Set `DBRoot` to an identifier common to your set of logs
+      * Set `DBName` to an identifier common to your set of logs
   * Filtering and whitelisting of connection logs happens at import time, and those optional settings can be found in the `/etc/rita/config.yaml` configuration file.
 
 #### Analyzing Data With RITA

--- a/commands/import.go
+++ b/commands/import.go
@@ -16,9 +16,9 @@ func init() {
 	importCommand := cli.Command{
 		Name:  "import",
 		Usage: "Import bro logs into a target database",
-		UsageText: "rita import [command options] [<import directory> <database root>]\n\n" +
+		UsageText: "rita import [command options] [<import directory> <database name>]\n\n" +
 			"Logs directly in <import directory> will be imported into a database" +
-			" named <database root>.\n<import directory> and <database root> will be" +
+			" named <database name>.\n<import directory> and <database name> will be" +
 			" loaded from the configuration file unless BOTH arguments are supplied.",
 		Flags: []cli.Flag{
 			threadFlag,
@@ -69,7 +69,7 @@ func (i *Importer) parseArgs() error {
 
 	//check if one argument is set but not the other
 	if i.importDir == "" || i.targetDatabase == "" {
-		return cli.NewExitError("\n\t[!] Both <directory to import> and <database prefix> are required.", -1)
+		return cli.NewExitError("\n\t[!] Both <directory to import> and <database name> are required.", -1)
 	}
 
 	err := i.checkForInvalidDBChars(i.targetDatabase)
@@ -122,7 +122,7 @@ func (i *Importer) setTargetDatabase() error {
 	}
 
 	i.res.DB.SelectDB(i.targetDatabase)
-	i.res.Config.S.Bro.DBRoot = i.targetDatabase
+	i.res.Config.S.Bro.DBName = i.targetDatabase
 
 	return nil
 }

--- a/commands/import.go
+++ b/commands/import.go
@@ -18,10 +18,8 @@ func init() {
 		Usage: "Import bro logs into a target database",
 		UsageText: "rita import [command options] [<import directory> <database root>]\n\n" +
 			"Logs directly in <import directory> will be imported into a database" +
-			" named <database root>. Files in a subfolder of <import directory> will be imported" +
-			" into <database root>-$SUBFOLDER_NAME. <import directory>" +
-			" and <database root> will be loaded from the configuration file unless" +
-			" BOTH arguments are supplied.",
+			" named <database root>.\n<import directory> and <database root> will be" +
+			" loaded from the configuration file unless BOTH arguments are supplied.",
 		Flags: []cli.Flag{
 			threadFlag,
 			configFlag,

--- a/config/static.go
+++ b/config/static.go
@@ -53,7 +53,7 @@ type (
 	//BroStaticCfg controls the file parser
 	BroStaticCfg struct {
 		ImportDirectory string `yaml:"ImportDirectory" default:"/opt/bro/logs/"`
-		DBRoot          string `yaml:"DBRoot" default:"RITA"`
+		DBName          string `yaml:"DBName" default:"RITA"`
 		MetaDB          string `yaml:"MetaDB" default:"MetaDatabase"`
 		ImportBuffer    int    `yaml:"ImportBuffer" default:"30000"`
 		Rolling         bool

--- a/config/static_test.go
+++ b/config/static_test.go
@@ -23,7 +23,7 @@ LogConfig:
     LogToDB: true
 Bro:
     ImportDirectory: /opt/bro/logs/
-    DBRoot: "RITA"
+    DBName: "RITA"
     MetaDB: MetaDatabase
     ImportBuffer: 100000
 UserConfig:
@@ -66,7 +66,7 @@ var testConfigFullExp = StaticCfg{
 	},
 	Bro: BroStaticCfg{
 		ImportDirectory: "/opt/bro/logs",
-		DBRoot:          "RITA",
+		DBName:          "RITA",
 		MetaDB:          "MetaDatabase",
 		ImportBuffer:    100000,
 	},

--- a/config/testing.go
+++ b/config/testing.go
@@ -20,7 +20,7 @@ LogConfig:
     LogToDB: true
 Bro:
     ImportDirectory: null
-    DBRoot: RITA-TEST
+    DBName: RITA-TEST
     MetaDB: RITA-TEST-MetaDatabase
     ImportBuffer: 100000
 BlackListed:

--- a/etc/rita.yaml
+++ b/etc/rita.yaml
@@ -40,9 +40,8 @@ Bro:
     ImportDirectory: /opt/bro/logs/
 
     # Files directly in the ImportDirectory will be imported into a database
-    # given by DBRoot. Files in a subfolder of ImportDirectory will be imported
-    # into DBRoot-$SUBFOLDER_NAME.
-    DBRoot: "RITA"
+    # with the name DBName.
+    DBName: "RITA"
 
     # This database holds information about the procesed files and databases.
     MetaDB: MetaDatabase

--- a/parser/fileparser.go
+++ b/parser/fileparser.go
@@ -33,10 +33,10 @@ func readDir(cpath string, logger *log.Logger) []string {
 		// Stop RITA from following symlinks
 		// In the case that RITA is pointed directly at Bro, it should not
 		// parse the "current" symlink which points to the spool.
-		if file.IsDir() && file.Mode() != os.ModeSymlink {
-			toReturn = append(toReturn, readDir(path.Join(cpath, file.Name()), logger)...)
-		}
-		if strings.HasSuffix(file.Name(), "gz") ||
+		// if file.IsDir() && file.Mode() != os.ModeSymlink {
+		// 	toReturn = append(toReturn, readDir(path.Join(cpath, file.Name()), logger)...)
+		// }
+		if !file.IsDir() && strings.HasSuffix(file.Name(), "gz") ||
 			strings.HasSuffix(file.Name(), "log") {
 			toReturn = append(toReturn, path.Join(cpath, file.Name()))
 		}

--- a/parser/indexedfile.go
+++ b/parser/indexedfile.go
@@ -1,13 +1,11 @@
 package parser
 
 import (
-	"bytes"
 	"crypto/md5"
 	"errors"
 	"fmt"
 	"io"
 	"os"
-	"strings"
 	"sync"
 
 	log "github.com/sirupsen/logrus"
@@ -85,11 +83,7 @@ func newIndexedFile(filePath string, config *config.Config,
 		return toReturn, errors.New("Could not find a target collection for file")
 	}
 
-	toReturn.TargetDatabase = getTargetDatabase(filePath, &config.S.Bro)
-	if toReturn.TargetDatabase == "" {
-		fileHandle.Close()
-		return toReturn, errors.New("Could not find a dataset for file")
-	}
+	toReturn.TargetDatabase = config.S.Bro.DBRoot
 
 	fileHandle.Close()
 	return toReturn, nil
@@ -112,27 +106,6 @@ func getFileHash(fileHandle *os.File, fInfo os.FileInfo) (string, error) {
 	fileHandle.Seek(0, 0)
 	var byteset []byte
 	return fmt.Sprintf("%x", hash.Sum(byteset)), nil
-}
-
-//getTargetDatabase assigns a database to a log file based on the path,
-//and the bro config
-func getTargetDatabase(filePath string, broConfig *config.BroStaticCfg) string {
-	var targetDatabase bytes.Buffer
-	targetDatabase.WriteString(broConfig.DBRoot)
-	//Append subfolders to target db
-	relativeStartIndex := len(broConfig.ImportDirectory)
-	pathSep := string(os.PathSeparator)
-	relativePath := filePath[relativeStartIndex+len(pathSep):]
-
-	//This routine uses Split rather than substring (0, index of path sep)
-	//because we may wish to add all the subdirectories to the db prefix
-	pathPieces := strings.Split(relativePath, pathSep)
-	//if there is more than just the file name
-	if len(pathPieces) > 1 {
-		targetDatabase.WriteString("-")
-		targetDatabase.WriteString(pathPieces[0])
-	}
-	return targetDatabase.String()
 }
 
 //indexFiles takes in a list of bro files, a number of threads, and parses

--- a/parser/indexedfile.go
+++ b/parser/indexedfile.go
@@ -83,7 +83,7 @@ func newIndexedFile(filePath string, config *config.Config,
 		return toReturn, errors.New("Could not find a target collection for file")
 	}
 
-	toReturn.TargetDatabase = config.S.Bro.DBRoot
+	toReturn.TargetDatabase = config.S.Bro.DBName
 
 	fileHandle.Close()
 	return toReturn, nil


### PR DESCRIPTION
Closes #417 

Fixes `rita delete XXX` such that the files that were imported into `XXX` from subdirectories are actually removed. 

Removes the ability to import log files from subdirectories. 

Renames DBRoot to DBName since nothing will be appended to the value. 
