### PR TITLE
Remove DBName, ImportDirectory Config Settings (Option 2)

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -59,12 +59,7 @@ Note that any value listed in the `Filtering` section should be in CIDR format. 
       * The automated installer for RITA installs pre-compiled Bro binaries
 
 #### Importing Data Into RITA
-  * After installing, `rita` should be in your `PATH` and the config file should be set up ready to go. Once your Bro install has collected some logs (Bro will normally rotate logs on the hour) you can run `rita import`. Alternatively, you can manually import existing logs using one of the following options:
-    * **Option 1**: Import directly from the terminal (one time import)
-      * `rita import path/to/your/bro_logs/ database_name`
-    * **Option 2**: Set up the Bro configuration in `/etc/rita/config.yaml` for repeated imports
-      * Set `ImportDirectory` to the `path/to/your/bro_logs`. The default is `/opt/bro/logs`
-      * Set `DBName` to an identifier common to your set of logs
+  * After installing, `rita` should be in your `PATH` and the config file should be set up, ready to go. Once your Bro install has collected some logs (Bro will normally rotate logs on the hour), you can run `rita import path/to/your/bro_logs/ database_name` to import the data into RITA and analyze it.
   * Filtering and whitelisting of connection logs happens at import time, and those optional settings can be found in the `/etc/rita/config.yaml` configuration file.
 
 #### Analyzing Data With RITA

--- a/config/static.go
+++ b/config/static.go
@@ -52,10 +52,10 @@ type (
 
 	//BroStaticCfg controls the file parser
 	BroStaticCfg struct {
-		ImportDirectory string `yaml:"ImportDirectory" default:"/opt/bro/logs/"`
-		DBName          string `yaml:"DBName" default:"RITA"`
 		MetaDB          string `yaml:"MetaDB" default:"MetaDatabase"`
 		ImportBuffer    int    `yaml:"ImportBuffer" default:"30000"`
+		ImportDirectory string
+		DBName          string
 		Rolling         bool
 		TotalChunks     int
 		CurrentChunk    int
@@ -141,7 +141,6 @@ func parseStaticConfig(cfgFile []byte, config *StaticCfg) error {
 
 	// clean all filepaths
 	config.Log.RitaLogPath = filepath.Clean(config.Log.RitaLogPath)
-	config.Bro.ImportDirectory = filepath.Clean(config.Bro.ImportDirectory)
 
 	// grab the version constants set by the build process
 	config.Version = Version

--- a/config/static_test.go
+++ b/config/static_test.go
@@ -22,8 +22,6 @@ LogConfig:
     LogToFile: true
     LogToDB: true
 Bro:
-    ImportDirectory: /opt/bro/logs/
-    DBName: "RITA"
     MetaDB: MetaDatabase
     ImportBuffer: 100000
 UserConfig:
@@ -65,10 +63,8 @@ var testConfigFullExp = StaticCfg{
 		LogToDB:     true,
 	},
 	Bro: BroStaticCfg{
-		ImportDirectory: "/opt/bro/logs",
-		DBName:          "RITA",
-		MetaDB:          "MetaDatabase",
-		ImportBuffer:    100000,
+		MetaDB:       "MetaDatabase",
+		ImportBuffer: 100000,
 	},
 	UserConfig: UserCfgStaticCfg{
 		UpdateCheckFrequency: 14,
@@ -117,15 +113,10 @@ func TestFilePathCleaning(t *testing.T) {
 	testConfig := `
 LogConfig:
     RitaLogPath: /var/lib/rita/incorrect/./../logs/
-Bro:
-    ImportDirectory: /opt/bro/incorrect/./../../bro/logs/
 `
 	testConfigExp := StaticCfg{
 		Log: LogStaticCfg{
 			RitaLogPath: "/var/lib/rita/logs",
-		},
-		Bro: BroStaticCfg{
-			ImportDirectory: "/opt/bro/logs",
 		},
 	}
 	config := &StaticCfg{}

--- a/config/testing.go
+++ b/config/testing.go
@@ -19,8 +19,6 @@ LogConfig:
     LogToFile: false
     LogToDB: true
 Bro:
-    ImportDirectory: null
-    DBName: RITA-TEST
     MetaDB: RITA-TEST-MetaDatabase
     ImportBuffer: 100000
 BlackListed:

--- a/etc/rita.yaml
+++ b/etc/rita.yaml
@@ -36,13 +36,6 @@ LogConfig:
 
 # The section Bro configures the bro ingestor
 Bro:
-    # Path to a top level directory of log files
-    ImportDirectory: /opt/bro/logs/
-
-    # Files directly in the ImportDirectory will be imported into a database
-    # with the name DBName.
-    DBName: "RITA"
-
     # This database holds information about the procesed files and databases.
     MetaDB: MetaDatabase
 


### PR DESCRIPTION
This PR addresses issue #421 by preventing the config parser from reading in the DBName and ImportDirectory fields. The corresponding fields are kept around in the config struct as they are used in a couple places by the file parser. 

An alternative PR #438 has been prepared which completely removes the config fields from the config struct in addition to removing the values in the config file.