### PR TITLE
Update Documentation for v3

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -24,16 +24,17 @@ The framework ingests [Bro/Zeek Logs](https://www.zeek.org/) in TSV format, and 
 ### Manual Installation
 To install each component of RITA by hand, [check out the instructions in the docs](docs/Manual%20Installation.md).
 
+### Upgrading RITA
+See [this guide](docs/Upgrading.md) for upgrade instructions.
+
 ### Getting Started
+
 #### System Requirements
 * Operating System - The preferred platform is 64-bit Ubuntu 16.04 LTS. The system should be patched and up to date using apt-get.
-* Processor (when also using Bro) - Two cores plus an additional core for every 100 Mb of traffic being captured. (three cores minimum). This should be dedicated hardware, as resource congestion with other VMs can cause packets to be dropped or missed.
+* Processor (when installed alongside Bro/Zeek) - Two cores plus an additional core for every 100 Mb of traffic being captured. (three cores minimum). This should be dedicated hardware, as resource congestion with other VMs can cause packets to be dropped or missed.
 * Memory - 16GB minimum. 64GB if monitoring 100Mb or more of network traffic. 128GB if monitoring 1Gb or more of network traffic.
 * Storage - 300GB minimum. 1TB or more is recommended to reduce log maintenance.
-* Network - In order to capture traffic with Bro, you will need at least 2 network interface cards (NICs). One will be for management of the system and the other will be the dedicated capture port. Intel NICs perform well and are recommended.
-
-#### Upgrading RITA
-See [this guide](docs/Upgrading.md) for upgrade instructions.
+* Network - In order to capture traffic with Bro/Zeek, you will need at least 2 network interface cards (NICs). One will be for management of the system and the other will be the dedicated capture port. Intel NICs perform well and are recommended.
 
 #### Configuration File
 RITA's config file is located at `/etc/rita/config.yaml` though you can specify a custom path on individual commands with the `-c` command line flag.
@@ -42,44 +43,70 @@ RITA's config file is located at `/etc/rita/config.yaml` though you can specify 
 * The `Filtering: InternalSubnets` section *must* be configured or you will not see any results in certain modules (e.g. beacons, long connections). If your network uses the standard RFC1918 internal IP ranges (10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16) you just need uncomment the default `InternalSubnets` section already in the config file. Otherwise, adjust this section to match your environment. RITA's main purpose is to find the signs of a compromised internal system talking to an external system and will automatically exclude internal to internal connections and external to external connections from parts of the analysis.
 
 You may also wish to change the defaults for the following option:
-* `Filtering: AlwaysInclude` - Ranges listed here are exempt from the filtering applied by the `IntenalSubnets` setting. The main use for this is to include internal DNS servers so that you can see the source of any DNS queries made.
+* `Filtering: AlwaysInclude` - Ranges listed here are exempt from the filtering applied by the `InternalSubnets` setting. The main use for this is to include internal DNS servers so that you can see the source of any DNS queries made.
 
 Note that any value listed in the `Filtering` section should be in CIDR format. So a single IP of `192.168.1.1` would be written as `192.168.1.1/32`.
 
-#### Obtaining Data (Generating Bro Logs):
-  * **Option 1**: Generate PCAPs outside of Bro
+#### Obtaining Data (Generating Bro/Zeek Logs):
+  * **Option 1**: Generate PCAPs outside of Bro/Zeek
     * Generate PCAP files with a packet sniffer ([tcpdump](http://www.tcpdump.org/), [wireshark](https://www.wireshark.org/), etc.)
     * (Optional) Merge multiple PCAP files into one PCAP file
       * `mergecap -w outFile.pcap inFile1.pcap inFile2.pcap`
-    * Generate bro logs from the PCAP files
+    * Generate Bro/Zeek logs from the PCAP files
       * ```bro -r pcap_to_log.pcap local "Log::default_rotation_interval = 1 day"```
 
-  * **Option 2**: Install Bro and let it monitor an interface directly [[instructions](https://www.bro.org/sphinx/quickstart/)]
-      * You may wish to [compile Bro from source](https://www.bro.org/sphinx/install/install.html) for performance reasons. [This script](https://github.com/activecm/bro-install) can help automate the process.
-      * The automated installer for RITA installs pre-compiled Bro binaries
+  * **Option 2**: Install Bro/Zeek and let it monitor an interface directly [[instructions](https://www.zeek.org/sphinx/quickstart/)]
+      * You may wish to [compile Bro/Zeek from source](https://www.zeek.org/sphinx/install/install.html) for performance reasons. [This script](https://github.com/activecm/bro-install) can help automate the process.
+      * The automated installer for RITA installs pre-compiled Bro/Zeek binaries by default
+        * Provide the `--disable-bro` flag when running the installer if you intend to compile Bro/Zeek from source
 
-#### Importing Data Into RITA
-  * After installing, `rita` should be in your `PATH` and the config file should be set up ready to go. Once your Bro install has collected some logs (Bro will normally rotate logs on the hour) you can run `rita import`. Alternatively, you can manually import existing logs using one of the following options:
-    * **Option 1**: Import directly from the terminal (one time import)
-      * `rita import path/to/your/bro_logs/ database_name`
-    * **Option 2**: Set up the Bro configuration in `/etc/rita/config.yaml` for repeated imports
-      * Set `ImportDirectory` to the `path/to/your/bro_logs`. The default is `/opt/bro/logs`
-      * Set `DBName` to an identifier common to your set of logs
-  * Filtering and whitelisting of connection logs happens at import time, and those optional settings can be found in the `/etc/rita/config.yaml` configuration file.
+#### Importing and Analyzing Data With RITA
+  After installing RITA, setting up the `InternalSubnets` section of the config file, and collecting some Bro/Zeek logs, you are ready to begin hunting.
 
-#### Analyzing Data With RITA
-  * **Option 1**: Analyze one dataset
-    * `rita analyze dataset_name`
-    * Ex: `rita analyze MyCompany_A`
-  * **Option 2**: Analyze all imported datasets
-    * `rita analyze`
+  Filtering and whitelisting happens at import time. These optional settings can be found alongside `InternalSubnets` in the configuration file.
+
+  RITA will process Bro/Zeek TSV logs in both plaintext and gzip compressed formats.
+
+  * **Option 1**: Create a One-Off Dataset
+      * `rita import path/to/your/bro_logs dataset_name` creates a dataset from a collection of Bro/Zeek logs in a directory 
+      * Every log file directly in the supplied directory will be imported into a dataset with the given name
+      * Once a dataset has been created in this fashion, no other data may be imported into the dataset
+  * **Option 2**: Create a Rolling Dataset
+      * Rolling datasets allow you to progressively analyze the last 24 hours of log data 
+      * RITA cycles data into and out of rolling databases in "chunks". Chunks are even divisions of a day. 
+          * For example, a rolling database configured to hold data in 4 chunks will import logs 6 hours at a time
+      * `rita import --rolling --numchunks # --chunk # path/to/your/bro_logs dataset_name` imports the logs in a given directory which match the period of time derived from the `numchunks` and `chunk` arguments
+      * `numchunks` controls how much data will be processed each time a rolling import is ran 
+          * The value supplied for `numchunks` must evenly divide 24 
+          * Valid choices are 1, 2, 3, 4, 6, 8, 12, and 24
+          * Each choice will process new data in 24, 12, 8, 4, 3, 2, and 1 hour periods, respectively  
+      * `chunk` tells RITA which period of data to import
+          * The value supplied for `chunk` must be between 1 and `numchunks` (inclusive)
+          * If `numchunks` is set to 4, and `chunk` is set to 2, RITA will import logs from 6 am to noon 
+      * Rolling databases should be routinely updated with new data
+          * `numchunks` should remain constant each time `import` is ran
+          * `chunk` should loop through 1 to `numchunks` (inclusive) as new data becomes available
+          * `chunk` should be reset to 1 once the last chunk has been imported
+      * RITA depends on the default naming scheme Bro/Zeek uses for hourly rotated logs. If your logs have been renamed, rolling imports will not work.
+
 
 #### Examining Data With RITA
   * Use the **show-X** commands
-  * `-H` displays human readable data
-  * `rita show-beacons dataset_name -H`
-  * `rita show-blacklisted dataset_name -H`
-  * Use less to view data `rita show-beacons dataset_name -H | less -S`
+      * `show-databases`: Print the datasets currently stored
+      * `show-beacons`: Print hosts which show signs of C2 software
+      * `show-bl-hostnames`: Print blacklisted hostnames which received connections
+      * `show-bl-source-ips`: Print blacklisted IPs which initiated connections
+      * `show-bl-dest-ips`: Print blacklisted IPs which received connections
+      * `show-exploded-dns`:  Print dns analysis. Exposes covert dns channels
+      * `show-long-connections`: Print long connections and relevant information
+      * `show-strobes`: Print connections which occurred with excessive frequency 
+      * `show-useragents`: Print user agent information
+  * By default RITA displays data in CSV format
+      * `-H` displays the data in a human readable format
+      * Piping the human readable results through `less -S` prevents word wrapping
+          * Ex: `rita show-beacons dataset_name -H | less -S`
+  * Create a html report with `html-report`
+  
 
 ### Getting help
 Please create an issue on GitHub if you have any questions or concerns.

--- a/Readme.md
+++ b/Readme.md
@@ -65,7 +65,7 @@ Note that any value listed in the `Filtering` section should be in CIDR format. 
 
   Filtering and whitelisting happens at import time. These optional settings can be found alongside `InternalSubnets` in the configuration file.
 
-  RITA will process Bro/Zeek TSV logs in both plaintext and gzip compressed formats.
+  RITA will process Bro/Zeek TSV logs in both plaintext and gzip compressed formats. Note, if you are using Security Onion or Bro's JSON log output you will need to [switch back to traditional TSV output](https://securityonion.readthedocs.io/en/latest/bro.html#tsv).
 
   * **Option 1**: Create a One-Off Dataset
       * `rita import path/to/your/bro_logs dataset_name` creates a dataset from a collection of Bro/Zeek logs in a directory 
@@ -84,10 +84,10 @@ Note that any value listed in the `Filtering` section should be in CIDR format. 
           * The value supplied for `chunk` must be between 1 and `numchunks` (inclusive)
           * If `numchunks` is set to 4, and `chunk` is set to 2, RITA will import logs from 6 am to noon 
       * Rolling databases should be routinely updated with new data
-          * `numchunks` should remain constant each time `import` is ran
+          * `numchunks` should remain constant each time `import` is ran on the same rolling dataset
           * `chunk` should loop through 1 to `numchunks` (inclusive) as new data becomes available
-          * `chunk` should be reset to 1 once the last chunk has been imported
-      * RITA depends on the default naming scheme Bro/Zeek uses for hourly rotated logs. If your logs have been renamed, rolling imports will not work.
+          * `chunk` should be reset to 1 once the last chunk has been imported. This causes the previous chunk 1 to be removed from the dataset before the new data is imported and ensures that the rolling dataset always contains at most 24 hours worth of data.
+      * RITA depends on the default naming scheme Bro/Zeek uses for hourly rotated logs. If your logs have been renamed, rolling imports will not work. In this case you should use Option 1 for creating a one-off dataset instead.
 
 
 #### Examining Data With RITA

--- a/docs/Docker Usage.md
+++ b/docs/Docker Usage.md
@@ -76,4 +76,4 @@ docker cp rita:/rita ./rita
 docker rm rita
 ```
 
-Note that you will have to manually install the `config.yaml` and `tables.yaml` files into `/etc/rita/` as well as create any directories referenced inside the `config.yaml` file.
+Note that you will have to manually install the `config.yaml` files into `/etc/rita/` as well as create any directories referenced inside the `config.yaml` file.

--- a/docs/Mongo Configuration.md
+++ b/docs/Mongo Configuration.md
@@ -1,6 +1,6 @@
 # Mongo Configuration for RITA
 
-This is the default MongoDB configuration section in RITA's configuration file `~/.rita/config.yaml`.
+This is the default MongoDB configuration section in RITA's configuration file `/etc/rita/config.yaml`.
 
 ```yaml
 MongoDB:
@@ -121,7 +121,7 @@ References:
 
 ### RITA Config
 
-To enable authentication and provide a username and password in RITA, modify the connection string in RITA's config file (`~/.rita/config.yaml`). 
+To enable authentication and provide a username and password in RITA, modify the connection string in RITA's config file (`/etc/rita/config.yaml`). 
 
 Of the possible values for `AuthenticationMechanism`, the only officially supported values are `null` or `SCRAM-SHA-1`.
 
@@ -192,7 +192,7 @@ References:
 
 ### RITA Config
 
-The following RITA configuration (`~/.rita/config.yaml`) snippet is sufficient to enable encrypted communication. Please note that while encryption and authentication are often used together, they are independent settings. The authentication settings aren't shown here but can be added.
+The following RITA configuration (`/etc/rita/config.yaml`) snippet is sufficient to enable encrypted communication. Please note that while encryption and authentication are often used together, they are independent settings. The authentication settings aren't shown here but can be added.
 
 Note: RITA does not support the common `?ssl=true` option on Mongo's connection string to enable encryption. You must use the `TLS` section of RITA's config file.
 

--- a/docs/Upgrading.md
+++ b/docs/Upgrading.md
@@ -7,7 +7,7 @@
 
 If you are upgrading across major versions (e.g. v1.x.x to v2.x.x, or v2.x.x to v3.x.x), you will need to delete your existing datasets and re-import them. Major version bumps typically bring massive performance gains as well as new features at the cost of removing compatibility for older datasets.
 
-You will likely need to update your config file as well. See the [Updating RITA's Config File](#Updating%20RITA's%20Config%20File) section below.
+You will likely need to update your config file as well. See the [Updating RITA's Config File](#updating-ritas-config-file) section below.
 
 ## Upgrading Between Minor or Patch Versions
 

--- a/docs/Upgrading.md
+++ b/docs/Upgrading.md
@@ -1,14 +1,21 @@
 # Upgrading RITA
 
-> :exclamation **IMPORTANT** :exclamation:
-> If you are upgrading to v3 from an earlier version, you will need to delete your existing datasets and re-import them. V3 brings massive performance gains at the cost of removing compatibility for older datasets. 
-
-Upgrading between versions of RITA is normally straightforward. Most often all you need to do is download the newest RITA binary and replace the one on your system. You can also use the appropriate `install.sh` installer to update between versions. Download and run the `install.sh` file from the [releases page](https://github.com/activecm/rita/releases) that corresponds with the version of RITA you wish to install.
-
-You may not need to update your config file at all as we include sane default settings for any new config value inside of RITA. This means that if your config file is missing a value, RITA will still have a default to use. However, if you need to customize any of these new values you'll have to update to the newer config file.
-
 > :exclamation: **IMPORTANT** :exclamation:
-> If you are upgrading to v2 from an earlier version you will need to modify your config file to include values for `Filtering: InternalSubnets`.
+> If you are upgrading from a version prior to v2 you will need to modify your config file to include values for `Filtering: InternalSubnets`.
+
+## Upgrading Between Major Versions
+
+If you are upgrading across major versions (e.g. v1.x.x to v2.x.x, or v2.x.x to v3.x.x), you will need to delete your existing datasets and re-import them. Major version bumps typically bring massive performance gains as well as new features at the cost of removing compatibility for older datasets.
+
+You will likely need to update your config file as well. See the [Updating RITA's Config File](#Updating%20RITA's%20Config%20File) section below.
+
+## Upgrading Between Minor or Patch Versions
+
+If you are upgrading within the same major version (e.g. v2.0.0 to v2.0.1, or v3.0.0 to v3.1.0) all you need to do is download the newest RITA binary and replace the one on your system. Alternatively, you can download and run the `install.sh` file from the [releases page](https://github.com/activecm/rita/releases) that corresponds with the version of RITA you wish to install.
+
+You may not need to update your config file at all as RITA includes sane default settings for any new config value. This means that if your config file is missing a value, RITA will still have a default to use. However, if you need to customize any of these new values you'll have to update to the newer config file.
+
+## Updating RITA's Config File
 
 In some cases you may also need to update your config file to a newer version. You can always find the latest config file in [`etc/rita.yml`](https://github.com/activecm/rita/blob/master/etc/rita.yaml). If you use the `install.sh` script, the correct version of the config file will be downloaded for you to `/etc/rita/config.yaml.new`.
 

--- a/docs/Upgrading.md
+++ b/docs/Upgrading.md
@@ -1,6 +1,9 @@
 # Upgrading RITA
 
-Updating between versions of RITA is normally straightforward. Most often all you need to do is download the newest RITA binary and replace the one on your system. You can also use the appropriate `install.sh` installer to update between versions. Download and run the `install.sh` file from the [releases page](https://github.com/activecm/rita/releases) that corresponds with the version of RITA you wish to install.
+> :exclamation **IMPORTANT** :exclamation:
+> If you are upgrading to v3 from an earlier version, you will need to delete your existing datasets and re-import them. V3 brings massive performance gains at the cost of removing compatibility for older datasets. 
+
+Upgrading between versions of RITA is normally straightforward. Most often all you need to do is download the newest RITA binary and replace the one on your system. You can also use the appropriate `install.sh` installer to update between versions. Download and run the `install.sh` file from the [releases page](https://github.com/activecm/rita/releases) that corresponds with the version of RITA you wish to install.
 
 You may not need to update your config file at all as we include sane default settings for any new config value inside of RITA. This means that if your config file is missing a value, RITA will still have a default to use. However, if you need to customize any of these new values you'll have to update to the newer config file.
 
@@ -14,4 +17,4 @@ To update the config file, transfer over any values you customized in your exist
 Here are other useful tips for comparing differences between configs:
 * Check the release notes for each of the versions of RITA for details on config file changes.
 * Run `diff /etc/rita/config.yaml /etc/rita/config.yaml.new` to see a summary of both your customizations and any changes to the new config.
-* Use `rita test-config` to see the config values RITA is using while it runs. This includes any default values set when your config file doesn't specify them. You can also specify a custom config file to further compare the differences like this: `rita test-config --config /etc/rita/config.yaml.new`.
+* Use `rita test-config` to see the config values RITA is using while it runs. This includes any default values set when your config file doesn't specify them. You can also specify a custom config file to further compare the differences like this: `rita test-config --config /etc/rita/config.yaml.new`. 


### PR DESCRIPTION
This PR is a first pass at addressing #441. 

This PR brings the main README.md up to date for v3, mainly focusing on the changes to the import process.

The README.md has been edited to reflect the absence of the analyze step and the addition of rolling datasets. 

In addition:
- references to Bro have been changed to Bro/Zeek in the main README
- `IntenalSubnets` typo has been fixed in the main README
- the "Examining Data" section has been updated to reflect the currently available `show-x` commands in the main README
- references to very old RITA configuration setups have been updated in the `docs/` folder
- a small blurb has been added to Upgrading.md regarding the v3 transition. We may want to rewrite Upgrading.md in its entirety. 