### PR TITLE
Renaming client_ips to src_ips

### DIFF
--- a/pkg/hostname/repository.go
+++ b/pkg/hostname/repository.go
@@ -21,7 +21,7 @@ type Input struct {
 type hostname struct {
 	host      string   `bson:"host"`
 	ips       []string `bson:"ips"`
-	clientIPs []string `bson:"client_ips"`
+	clientIPs []string `bson:"src_ips"`
 }
 
 //ritaBLResult contains the summary of a result from the "ip" collection of rita-bl


### PR DESCRIPTION
[This commit](https://github.com/activecm/rita/pull/436/commits/9b107601f891b1b8082865f367b785fc66bebe1b) renamed the mongo field from `client_ips` to `src_ips`, but it missed one.

I'm not entirely sure this has any effect.  I think that those bson tags in the repository.go file aren't actually being used as the analyzer.go file crafts a query where the field is set explicitly anyway.  So maybe instead of this change, we could determine where these tags aren't being used and remove them.