### PR TITLE
Removing Bro config section

### DIFF
--- a/config/static.go
+++ b/config/static.go
@@ -20,7 +20,7 @@ type (
 		Beacon       BeaconStaticCfg      `yaml:"Beacon"`
 		DNS          DNSStaticCfg         `yaml:"DNS"`
 		UserAgent    UserAgentStaticCfg   `yaml:"UserAgent"`
-		Bro          BroStaticCfg         `yaml:"Bro"`
+		Bro          BroStaticCfg         `yaml:"Bro"`		// kept in for MetaDB backwards compatibility
 		Filtering    FilteringStaticCfg   `yaml:"Filtering"`
 		Strobe       StrobeStaticCfg      `yaml:"Strobe"`
 		Version      string
@@ -53,6 +53,7 @@ type (
 
 	//BroStaticCfg controls the file parser
 	BroStaticCfg struct {
+		MetaDB       string `yaml:"MetaDB"`  // kept in for backwards compatibility
 		Rolling      bool
 		TotalChunks  int
 		CurrentChunk int
@@ -127,6 +128,12 @@ func parseStaticConfig(cfgFile []byte, config *StaticCfg) error {
 
 	if err != nil {
 		return err
+	}
+
+	// migrate MetaDB entry from old location (Bro:MetaDB) if there is a value in the
+	// old location and the new location (MongoDB:MetaDB) is still the default (MetaDatabase)
+	if config.Bro.MetaDB != "" && config.MongoDB.MetaDB == "MetaDatabase" {
+		config.MongoDB.MetaDB = config.Bro.MetaDB
 	}
 
 	// expand env variables, config is a pointer

--- a/config/static.go
+++ b/config/static.go
@@ -33,6 +33,7 @@ type (
 		AuthMechanism    string        `yaml:"AuthenticationMechanism" default:""`
 		SocketTimeout    time.Duration `yaml:"SocketTimeout" default:"2"`
 		TLS              TLSStaticCfg  `yaml:"TLS"`
+		MetaDB           string        `yaml:"MetaDB" default:"MetaDatabase"`
 	}
 
 	//TLSStaticCfg contains the means for connecting to MongoDB over TLS
@@ -52,8 +53,6 @@ type (
 
 	//BroStaticCfg controls the file parser
 	BroStaticCfg struct {
-		MetaDB       string `yaml:"MetaDB" default:"MetaDatabase"`
-		ImportBuffer int    `yaml:"ImportBuffer" default:"30000"`
 		Rolling      bool
 		TotalChunks  int
 		CurrentChunk int

--- a/config/static_test.go
+++ b/config/static_test.go
@@ -16,14 +16,12 @@ MongoDB:
         Enable: false
         VerifyCertificate: false
         CAFile: aaaaa
+    MetaDB: MetaDatabase
 LogConfig:
     LogLevel: 2
     RitaLogPath: /var/lib/rita/logs
     LogToFile: true
     LogToDB: true
-Bro:
-    MetaDB: MetaDatabase
-    ImportBuffer: 100000
 UserConfig:
     UpdateCheckFrequency: 14
 BlackListed:
@@ -55,16 +53,13 @@ var testConfigFullExp = StaticCfg{
 			VerifyCertificate: false,
 			CAFile:            "aaaaa",
 		},
+		MetaDB:       "MetaDatabase",
 	},
 	Log: LogStaticCfg{
 		LogLevel:    2,
 		RitaLogPath: "/var/lib/rita/logs",
 		LogToFile:   true,
 		LogToDB:     true,
-	},
-	Bro: BroStaticCfg{
-		MetaDB:       "MetaDatabase",
-		ImportBuffer: 100000,
 	},
 	UserConfig: UserCfgStaticCfg{
 		UpdateCheckFrequency: 14,

--- a/config/testing.go
+++ b/config/testing.go
@@ -13,14 +13,12 @@ MongoDB:
         Enable: false
         VerifyCertificate: false
         CAFile: null
+    MetaDB: RITA-TEST-MetaDatabase
 LogConfig:
     LogLevel: 3
     RitaLogPath: null
     LogToFile: false
     LogToDB: true
-Bro:
-    MetaDB: RITA-TEST-MetaDatabase
-    ImportBuffer: 100000
 BlackListed:
     myIP.ms: false
     MalwareDomains.com: false

--- a/etc/rita.yaml
+++ b/etc/rita.yaml
@@ -1,3 +1,4 @@
+# This section configures the connection to the MongoDB server and the database name to use
 MongoDB:
     # See https://docs.mongodb.com/manual/reference/connection-string/
     ConnectionString: mongodb://localhost:27017
@@ -19,6 +20,9 @@ MongoDB:
         #If set, RITA will use the provided CA file instead of the system's CA's
         CAFile: null
 
+    # This database holds information about the procesed files and databases.
+    MetaDB: MetaDatabase
+
 LogConfig:
     # LogLevel
     # 3 = debug
@@ -33,16 +37,6 @@ LogConfig:
 
     LogToFile: true
     LogToDB: true
-
-# The section Bro configures the bro ingestor
-Bro:
-    # This database holds information about the procesed files and databases.
-    MetaDB: MetaDatabase
-
-    # The number of records shipped off to MongoDB at a time. Increasing
-    # the size of the buffer will improve import timings at the expense
-    # of using more RAM.
-    ImportBuffer: 30000
 
 UserConfig:
     # Number of days before checking for a new version of RITA.

--- a/resources/resources.go
+++ b/resources/resources.go
@@ -46,7 +46,7 @@ func InitResources(userConfig string) *Resources {
 	if conf.S.Log.LogToDB {
 		log.Hooks.Add(
 			mgorus.NewHookerFromSession(
-				db.Session, conf.S.Bro.MetaDB, conf.T.Log.RitaLogTable,
+				db.Session, conf.S.MongoDB.MetaDB, conf.T.Log.RitaLogTable,
 			),
 		)
 	}

--- a/resources/testing.go
+++ b/resources/testing.go
@@ -47,7 +47,7 @@ func InitIntegrationTestingResources(t *testing.T) *Resources {
 	if conf.S.Log.LogToDB {
 		log.Hooks.Add(
 			mgorus.NewHookerFromSession(
-				db.Session, conf.S.Bro.MetaDB, conf.T.Log.RitaLogTable,
+				db.Session, conf.S.MongoDB.MetaDB, conf.T.Log.RitaLogTable,
 			),
 		)
 	}
@@ -89,7 +89,7 @@ func InitTestResources() *Resources {
 	if conf.S.Log.LogToDB {
 		log.Hooks.Add(
 			mgorus.NewHookerFromSession(
-				db.Session, conf.S.Bro.MetaDB, conf.T.Log.RitaLogTable,
+				db.Session, conf.S.MongoDB.MetaDB, conf.T.Log.RitaLogTable,
 			),
 		)
 	}


### PR DESCRIPTION
I removed the `ImportBuffer` config item since it was not being used in the code.  This left only `MetaDB` under the `Bro` config section.  Since this didn't really seem to belong in this section anymore I moved `MetaDB` to the `MongoDB` section.

The `BroStaticCfg` struct in `config/static.go` is still being used to store the rolling analysis command line options so I didn't completely remove this. If we have a better place for these values, we could get rid of this struct too.

I built rita, imported a dataset, and confirmed that there were beacon results. Additionally, `make test` passes.  

Anyone using an old config file will revert to the default of "MetaDatabase" for the `MetaDB` field since they won't have this under the `MongoDB` section. This could cause anyone who changed their default metadatabase value to not see their databases until they migrate their config file to the new format. Because of this, I'd like to hear other thoughts on how to handle this. We could: 
1. Not move the MetaDB config value.  It seems silly to leave it in a place that no longer makes sense indefinitely due to backwards compatibility, though I could go along with holding off until we break backwards compatibility for a better reason in the future.
2. Add code to detect that MetaDB is missing and print a warning/error that they should move their old config value.
3. Add code to fallback on checking the old location if the new location doesn't exist.