### PR TITLE
449-useragent-overflow

### DIFF
--- a/pkg/certificate/mongodb.go
+++ b/pkg/certificate/mongodb.go
@@ -85,6 +85,12 @@ func (r *repo) Upsert(certMap map[string]*Input) {
 	// loop over map entries
 	for key, value := range certMap {
 		start := time.Now()
+		//Mongo Index key is limited to a size of 1024 https://docs.mongodb.com/v3.4/reference/limits/#index-limitations
+		//  so if the key is too large, we should cut it back, this is rough but
+		//  works. Figured 800 allows some wiggle room, while also not being too large
+		if len(key) > 1024 {
+			key = key[:800]
+		}
 		value.Host = key
 		analyzerWorker.collect(value)
 		bar.IncrBy(1, time.Since(start))

--- a/pkg/explodeddns/mongodb.go
+++ b/pkg/explodeddns/mongodb.go
@@ -89,6 +89,12 @@ func (r *repo) Upsert(domainMap map[string]int) {
 	// loop over map entries
 	for entry, count := range domainMap {
 		start := time.Now()
+		//Mongo Index key is limited to a size of 1024 https://docs.mongodb.com/v3.4/reference/limits/#index-limitations
+		//  so if the key is too large, we should cut it back, this is rough but
+		//  works. Figured 800 allows some wiggle room, while also not being too large
+		if len(entry) > 1024 {
+			entry = entry[:800]
+		}
 		analyzerWorker.collect(domain{entry, count})
 		bar.IncrBy(1, time.Since(start))
 	}

--- a/pkg/hostname/mongodb.go
+++ b/pkg/hostname/mongodb.go
@@ -87,6 +87,12 @@ func (r *repo) Upsert(hostnameMap map[string]*Input) {
 	// loop over map entries
 	for entry, ipLists := range hostnameMap {
 		start := time.Now()
+		//Mongo Index key is limited to a size of 1024 https://docs.mongodb.com/v3.4/reference/limits/#index-limitations
+		//  so if the key is too large, we should cut it back, this is rough but
+		//  works. Figured 800 allows some wiggle room, while also not being too large
+		if len(entry) > 1024 {
+			entry = entry[:800]
+		}
 		analyzerWorker.collect(hostname{
 			host:      entry,
 			ips:       ipLists.ResolvedIPs,

--- a/pkg/useragent/mongodb.go
+++ b/pkg/useragent/mongodb.go
@@ -89,6 +89,12 @@ func (r *repo) Upsert(userAgentMap map[string]*Input) {
 	// loop over map entries
 	for key, value := range userAgentMap {
 		start := time.Now()
+		//Mongo Index key is limited to a size of 1024 https://docs.mongodb.com/v3.4/reference/limits/#index-limitations
+		//  so if the key is too large, we should cut it back, this is rough but
+		//  works. Figured 800 allows some wiggle room, while also not being too large
+		if len(key) > 1024 {
+			key = key[:800]
+		}
 		value.name = key
 		analyzerWorker.collect(value)
 		bar.IncrBy(1, time.Since(start))


### PR DESCRIPTION
Some of the keys for index files (particularly the Useragent keys) were causing overflow to the max key length. This is caused by the max index key size being 1024 bytes.
This PR checks the key length in the Upsert function in various analyzers to ensure we don't overstep that 1024 limiter.

Closes: #449