### PR TITLE
Empty UCONN Warning

### DIFF
--- a/parser/fsimporter.go
+++ b/parser/fsimporter.go
@@ -769,6 +769,8 @@ func (fs *FSImporter) buildUconns(uconnMap map[string]*uconn.Pair) {
 		uconnRepo.Upsert(uconnMap)
 	} else {
 		fmt.Println("\t[!] No Uconn data to analyze")
+		fmt.Printf("\t\t[!!] No local network traffic found, please check ")
+		fmt.Println("InternalSubnets in your RTIA config (/etc/rita/config.yaml)")
 	}
 
 }
@@ -787,6 +789,8 @@ func (fs *FSImporter) buildHosts(hostMap map[string]*host.IP) {
 		hostRepo.Upsert(hostMap)
 	} else {
 		fmt.Println("\t[!] No Host data to analyze")
+		fmt.Printf("\t\t[!!] No local network traffic found, please check ")
+		fmt.Println("InternalSubnets in your RTIA config (/etc/rita/config.yaml)")
 	}
 }
 


### PR DESCRIPTION
This adds a warning to the import of a database. If the user runs import currently it will just move past UCONN and Host data and keep evaluating. If the user has their config improperly configured then tracking that issue down could be tricky. This adds a couple lines that says the UCONN data is empty and they should double check their config file (since it seems weird that someone would run data with no local traffic)