### PR TITLE
Fix for if InternalSubnets is updated

### DIFF
--- a/pkg/host/analyzer.go
+++ b/pkg/host/analyzer.go
@@ -106,15 +106,12 @@ func standardQuery(chunk int, chunkStr string, ip string, local bool, ip4 bool, 
 
 	// create query
 	query := bson.M{
-		"$setOnInsert": bson.M{
-			"ipv4_binary": ip4bin,
-			"ipv4":        ip4,
-		},
-
 		"$set": bson.M{
 			"blacklisted": blacklisted,
 			"cid":         chunk,
 			"local":       local,
+			"ipv4":        ip4,
+			"ipv4_binary": ip4bin,
 		},
 	}
 

--- a/pkg/host/analyzer.go
+++ b/pkg/host/analyzer.go
@@ -107,12 +107,15 @@ func standardQuery(chunk int, chunkStr string, ip string, local bool, ip4 bool, 
 	// create query
 	query := bson.M{
 		"$setOnInsert": bson.M{
-			"local":       local,
 			"ipv4_binary": ip4bin,
 			"ipv4":        ip4,
 		},
 
-		"$set": bson.M{"blacklisted": blacklisted, "cid": chunk},
+		"$set": bson.M{
+			"blacklisted": blacklisted,
+			"cid":         chunk,
+			"local":       local,
+		},
 	}
 
 	if newFlag {

--- a/pkg/uconn/analyzer.go
+++ b/pkg/uconn/analyzer.go
@@ -55,7 +55,7 @@ func (a *analyzer) start() {
 
 			// create query
 			query := bson.M{
-				"$setOnInsert": bson.M{
+				"$set": bson.M{
 					"local_src": data.IsLocalSrc,
 					"local_dst": data.IsLocalDst,
 				},


### PR DESCRIPTION
If InternalSubnets is changed and new data is imported into a rolling database, any existing hosts (IPs) in the database wouldn't be updated based on the new value of InternalSubnets. For instance, if you had an IP of "22.22.22.22" that was not included in the InternalSubnets it would be marked as `{local: false}` in the host database entry. If you added this IP to your InternalSubnets you'd expect it to then have `{local: true}`. However, since the entry already existed it wouldn't be updated. 

This pull request makes this change, along with several other fields that could be affected in the same way.