### PR TITLE
Force rita to be rebuilt

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,8 @@ SRC := $(shell find . -path ./vendor -prune -o -type f -name '*.go' -print)
 # https://www.cmcrossroads.com/article/makefile-optimization-eval-and-macro-caching
 cache = $(if $(cached-$1),,$(eval cached-$1 := 1)$(eval cache-$1 := $($1)))$(cache-$1)
 
-# The first recipe defined will be called when `make` is run without a target
+# force rita to be rebuilt even if it's up to date
+.PHONY: rita
 rita: vendor $(SRC)
 	go build ${LDFLAGS}
 


### PR DESCRIPTION
If you try to use a `rita` binary that is built using `go build` without the proper version flags rita will fail to run with this message:
```
./rita  -version
rita version undefined
	[!] Version error: please ensure that you cloned the git repo and are using make to build.
	[!] See the following resources for further information:
	[>] https://github.com/activecm/rita/blob/master/Contributing.md#common-issues
	[>] https://github.com/activecm/rita/blob/master/docs/Manual%20Installation.md
Failed to config: Invalid character(s) found in major number "undefined"
```

If you try to fix this problem by them running `make`, make will not rebuild the rita binary because the binary's create/modify time are newer than any of its dependencies. This can lead to confusion.

This pull request makes the `rita` build target `.PHONY` which causes make to rebuild it unconditionally.
