### PR TITLE
Add install.sh support for Ubuntu 18.04

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -410,6 +410,9 @@ __gather_OS() {
 		exit 1
 	fi
 
+	# There is no official repository for Mongo3.6 on Ubuntu 18.04 Bionic.
+	# Documentation recommends using the xenial keyword in repos to install Mongo 3.6:
+	# https://linuxconfig.org/how-to-install-latest-mongodb-on-ubuntu-18-04-bionic-beaver-linux
 	if [ "$_MONGO_OS_CODENAME" == "bionic" ]; then
 		_MONGO_OS_CODENAME="xenial"
 	fi

--- a/install.sh
+++ b/install.sh
@@ -411,7 +411,7 @@ __gather_OS() {
 	fi
 
 	# There is no official repository for Mongo3.6 on Ubuntu 18.04 Bionic.
-	# Documentation recommends using the xenial keyword in repos to install Mongo 3.6:
+	# Documentation recommends using the xenial codename in repos to install Mongo 3.6:
 	# https://linuxconfig.org/how-to-install-latest-mongodb-on-ubuntu-18-04-bionic-beaver-linux
 	if [ "$_MONGO_OS_CODENAME" == "bionic" ]; then
 		_MONGO_OS_CODENAME="xenial"

--- a/install.sh
+++ b/install.sh
@@ -314,7 +314,7 @@ __add_bro_to_path() {
 __install_mongodb() {
 	case "$_OS" in
 		Ubuntu)
-			__add_deb_repo "deb [ arch=$(dpkg --print-architecture) ] http://repo.mongodb.org/apt/ubuntu $(lsb_release -cs)/mongodb-org/${_MONGO_VERSION} multiverse" \
+			__add_deb_repo "deb [ arch=$(dpkg --print-architecture) ] http://repo.mongodb.org/apt/ubuntu ${_MONGO_OS_CODENAME}/mongodb-org/${_MONGO_VERSION} multiverse" \
 				"mongodb-org-${_MONGO_VERSION}" \
 				"https://www.mongodb.org/static/pgp/server-${_MONGO_VERSION}.asc"
 			;;
@@ -402,10 +402,16 @@ __install_rita() {
 __gather_OS() {
 	_OS="$(lsb_release -is)"
 	_OS_CODENAME="$(lsb_release -cs)"
+	_MONGO_OS_CODENAME="$(lsb_release -cs)"
+
 	if [ "$_OS" != "Ubuntu" -a "$_OS" != "CentOS" -a "$_OS" != "RedHatEnterpriseServer" ]; then
 		printf "$_ITEM This installer supports Ubuntu, CentOS, and RHEL. \n"
 		printf "$_IMPORTANT Your operating system is unsupported."
 		exit 1
+	fi
+
+	if [ "$_MONGO_OS_CODENAME" == "bionic" ]; then
+		_MONGO_OS_CODENAME="xenial"
 	fi
 }
 


### PR DESCRIPTION
Only small changes here.

Added a conditional in the function `__gather_OS()` to add a new variable, `_MONGO_OS_CODENAME`. I then changed the `__install_mongodb()` function's reference from `$(lsb_release -cs)` to `${_MONGO_OS_CODENAME}`.

Hopefully this all looks good!

Thanks.