### PR TITLE
Allow Users to Re-Import Logs

### DIFF
--- a/commands/commands.go
+++ b/commands/commands.go
@@ -55,7 +55,7 @@ var (
 	// before importing the target data
 	deleteFlag = cli.BoolFlag{
 		Name:  "delete, D",
-		Usage: "Indicates that the existing dataset should be deleted before re-importing. If the dataset is a rolling dataset, --chunk is required.",
+		Usage: "Indicates that the existing dataset should be deleted before re-importing. If the dataset is a rolling dataset and --chunk is not specified, the latest chunk will be replaced.",
 	}
 
 	rollingFlag = cli.BoolFlag{

--- a/commands/commands.go
+++ b/commands/commands.go
@@ -51,6 +51,13 @@ var (
 		Usage: "Tests which databases would be deleted. Does not actually delete any data, nor prompt for confirmation",
 	}
 
+	// deleteFlag indicates whether any matching, existing data should be deleted
+	// before importing the target data
+	deleteFlag = cli.BoolFlag{
+		Name:  "delete, D",
+		Usage: "Indicates that the existing dataset should be deleted before re-importing. If the dataset is a rolling dataset, --chunk is required.",
+	}
+
 	rollingFlag = cli.BoolFlag{
 		Name:  "rolling, R",
 		Usage: "Indicates rolling import, which builds on and removes data to maintain a fixed length of time",

--- a/commands/delete-database.go
+++ b/commands/delete-database.go
@@ -110,7 +110,7 @@ func deleteDatabase(c *cli.Context) error {
 
 	// Iterate through databases to delete and delete them one by one
 	for _, database := range names {
-		dberr := deleteSingleDatabase(res, names, database, dryRun)
+		dberr := deleteSingleDatabase(res, database, dryRun)
 		if dberr != nil {
 			return cli.NewExitError(dberr.Error, -1)
 		}
@@ -124,10 +124,13 @@ func deleteDatabase(c *cli.Context) error {
 	return nil
 }
 
-func deleteSingleDatabase(res *resources.Resources, dbnames []string, db string, dryRun bool) error {
+func deleteSingleDatabase(res *resources.Resources, db string, dryRun bool) error {
 	// check if database exists
-	dbExists := util.StringInSlice(db, dbnames)
-
+	collNames, err := res.DB.Session.DB(db).CollectionNames()
+	if err != nil {
+		return err
+	}
+	dbExists := len(collNames) != 0
 	// check if metadatabase record for database exists
 	mDBExists := util.StringInSlice(db, res.MetaDB.GetDatabases())
 

--- a/commands/import.go
+++ b/commands/import.go
@@ -237,9 +237,10 @@ func (i *Importer) run() error {
 		return cli.NewExitError("Internal subnets are not defined. Please set the InternalSubnets section of the config file.", -1)
 	}
 
-	indexedFiles, err := importer.CollectFileDetails()
-	if err != nil {
-		return cli.NewExitError(err.Error(), -1)
+	indexedFiles := importer.CollectFileDetails()
+	// if no compatible files for import were found, exit
+	if len(indexedFiles) == 0 {
+		return cli.NewExitError("No compatible log files found", -1)
 	}
 
 	if i.deleteOldData {

--- a/commands/import.go
+++ b/commands/import.go
@@ -237,6 +237,11 @@ func (i *Importer) run() error {
 		return cli.NewExitError("Internal subnets are not defined. Please set the InternalSubnets section of the config file.", -1)
 	}
 
+	indexedFiles, err := importer.CollectFileDetails()
+	if err != nil {
+		return cli.NewExitError(err.Error(), -1)
+	}
+
 	if i.deleteOldData {
 		err := i.handleDeleteOldData()
 		if err != nil {
@@ -253,7 +258,8 @@ func (i *Importer) run() error {
 		fmt.Printf("\t[+] Non-rolling database %v will be converted to rolling\n", i.targetDatabase)
 	}
 
-	importer.Run()
+
+	importer.Run(indexedFiles)
 
 	i.res.Log.Infof("Finished importing %v\n", i.importFiles)
 

--- a/commands/import_test.go
+++ b/commands/import_test.go
@@ -69,10 +69,10 @@ func TestParseFlags(t *testing.T) {
 		tc{"rita import --chunk 12 --numchunks 24 (default 12)",
 			!exists, !rolling, 0, 0, !rolling, 12, 24, default12, !delete, cfg{12, rolling, 12, 24}, !returnsError},
 
-		tc{"rita import --chunk -2 (default 12)",
+		tc{"rita import --chunk -2 (default 12)", // error reason: chunk number must be positive
 			!exists, !rolling, 0, 0, !rolling, -2, blank, default12, !delete, cfg{}, returnsError},
 
-		tc{"rita import --numchunks -2 (default 12)",
+		tc{"rita import --numchunks -2 (default 12)", // error reason: numchunks must be positive
 			!exists, !rolling, 0, 0, !rolling, blank, -2, default12, !delete, cfg{}, returnsError},
 
 		tc{"rita import --delete (default 12)",
@@ -90,7 +90,7 @@ func TestParseFlags(t *testing.T) {
 		// existing database scenarios
 
 		// non-rolling, current chunk 0, total chunks 1
-		tc{"rita import",
+		tc{"rita import", // error reason: cannot import into existing non-rolling db
 			exists, !rolling, 0, 1, !rolling, blank, blank, default12, !delete, cfg{}, returnsError},
 
 		tc{"rita import --rolling",
@@ -114,10 +114,10 @@ func TestParseFlags(t *testing.T) {
 		tc{"rita import --chunk 12 --numchunks 24",
 			exists, !rolling, 0, 1, !rolling, 12, 24, default12, !delete, cfg{12, rolling, 12, 24}, !returnsError},
 
-		tc{"rita import --chunk -2",
+		tc{"rita import --chunk -2", // error reason: chunk number must be positive
 			exists, !rolling, 0, 1, !rolling, -2, blank, default12, !delete, cfg{}, returnsError},
 
-		tc{"rita import --numchunks -2",
+		tc{"rita import --numchunks -2", // error reason: numchunks must be positive
 			exists, !rolling, 0, 1, !rolling, blank, -2, default12, !delete, cfg{}, returnsError},
 
 		tc{"rita import --delete (default 12)",
@@ -148,19 +148,19 @@ func TestParseFlags(t *testing.T) {
 		tc{"rita import --chunk 5 (default 12)",
 			exists, rolling, 1, 12, !rolling, 5, blank, default12, !delete, cfg{12, rolling, 5, 12}, !returnsError},
 
-		tc{"rita import --chunk 12 (default 12)",
+		tc{"rita import --chunk 12 (default 12)", // error reason: chunk must be less than db numchunks
 			exists, rolling, 1, 12, !rolling, 12, blank, default12, !delete, cfg{}, returnsError},
 
-		tc{"rita import --chunk 12 (default 24)",
+		tc{"rita import --chunk 12 (default 24)", // error reason: chunk must be less than db numchunks
 			exists, rolling, 1, 12, !rolling, 12, blank, default24, !delete, cfg{}, returnsError},
 
 		tc{"rita import --chunk 12 --numchunks 24",
 			exists, rolling, 1, 12, !rolling, 12, 24, default12, !delete, cfg{12, rolling, 12, 24}, !returnsError},
 
-		tc{"rita import --chunk -2",
+		tc{"rita import --chunk -2", // error reason: chunk number must be positive
 			exists, rolling, 1, 12, !rolling, -2, blank, default12, !delete, cfg{}, returnsError},
 
-		tc{"rita import --numchunks -2",
+		tc{"rita import --numchunks -2", // error reason: numchunks must be positive
 			exists, rolling, 1, 12, !rolling, blank, -2, default12, !delete, cfg{}, returnsError},
 
 		tc{"rita import --delete (default 12)",
@@ -191,10 +191,10 @@ func TestParseFlags(t *testing.T) {
 		tc{"rita import --chunk 5 (default 12)",
 			exists, rolling, 11, 12, !rolling, 5, blank, default12, !delete, cfg{12, rolling, 5, 12}, !returnsError},
 
-		tc{"rita import --chunk 12 (default 12)",
+		tc{"rita import --chunk 12 (default 12)", // error reason: chunk must be less than db numchunks
 			exists, rolling, 11, 12, !rolling, 12, blank, default12, !delete, cfg{}, returnsError},
 
-		tc{"rita import --chunk 12 (default 24)",
+		tc{"rita import --chunk 12 (default 24)", // error reason: chunk must be less than db numchunks
 			exists, rolling, 11, 12, !rolling, 12, blank, default24, !delete, cfg{}, returnsError},
 
 		tc{"rita import --chunk 12 --numchunks 24",
@@ -222,10 +222,10 @@ func TestParseFlags(t *testing.T) {
 		tc{"rita import --rolling --chunk 0 --numchunks 24",
 			exists, rolling, 11, 24, rolling, 0, 24, default12, !delete, cfg{12, rolling, 0, 24}, !returnsError},
 
-		tc{"rita import --numchunks 12",
+		tc{"rita import --numchunks 12", // error reason: cannot reduce the number of chunks
 			exists, rolling, 11, 24, !rolling, blank, 12, default12, !delete, cfg{}, returnsError},
 
-		tc{"rita import --chunk 12 --numchunks 12",
+		tc{"rita import --chunk 12 --numchunks 12", // error reason: cannot reduce the number of chunks
 			exists, rolling, 11, 24, !rolling, 12, 12, default12, !delete, cfg{}, returnsError},
 
 		tc{"rita import --chunk 13 (default 12)",
@@ -265,6 +265,7 @@ func TestParseFlags(t *testing.T) {
 		if testCase.err {
 			assert.Errorf(t, err, "db: <%s> cmd: <%s>", dbMsg, testCase.msg)
 		} else {
+			assert.NoErrorf(t, err,"db: <%s> cmd: <%s>", dbMsg, testCase.msg)
 			assert.Equalf(t, testCase.expected, actual, "db: <%s> cmd: <%s>", dbMsg, testCase.msg)
 		}
 	}

--- a/commands/import_test.go
+++ b/commands/import_test.go
@@ -1,8 +1,8 @@
 package commands
 
 import (
-	"testing"
 	"fmt"
+	"testing"
 
 	"github.com/stretchr/testify/assert"
 
@@ -16,18 +16,18 @@ func TestSetRolling(t *testing.T) {
 	// 	CurrentChunk  int
 	// 	TotalChunks   int
 
-	type tc struct{
-		msg string
-		dbExists bool
-		dbIsRolling bool
-		dbCurrChunk int
-		dbTotalChunks int
-		userIsRolling bool
-		userCurrChunk int
-		userTotalChunks int
+	type tc struct {
+		msg              string
+		dbExists         bool
+		dbIsRolling      bool
+		dbCurrChunk      int
+		dbTotalChunks    int
+		userIsRolling    bool
+		userCurrChunk    int
+		userTotalChunks  int
 		cfgDefaultChunks int
-		expected cfg
-		err bool
+		expected         cfg
+		err              bool
 	}
 
 	// this is the sentinel value that signifies that a user did not supply
@@ -44,149 +44,149 @@ func TestSetRolling(t *testing.T) {
 		// new database scenarios
 
 		tc{"rita import (default 12)",
-			!exists, !rolling, 0, 0, !rolling, blank, blank, default12, cfg{0, !rolling, 0, 1}, !returnsError},
+			!exists, !rolling, 0, 0, !rolling, blank, blank, default12, cfg{12, !rolling, 0, 1}, !returnsError},
 
 		tc{"rita import --rolling (default 12)",
-			!exists, !rolling, 0, 0, rolling, blank, blank, default12, cfg{0, rolling, 0, 12}, !returnsError},
+			!exists, !rolling, 0, 0, rolling, blank, blank, default12, cfg{12, rolling, 0, 12}, !returnsError},
 
 		tc{"rita import --rolling --chunk 0 --numchunks 24 (default 12)",
-			!exists, !rolling, 0, 0, rolling, 0, 24, default12, cfg{0, rolling, 0, 24}, !returnsError},
+			!exists, !rolling, 0, 0, rolling, 0, 24, default12, cfg{12, rolling, 0, 24}, !returnsError},
 
 		tc{"rita import --numchunks 24 (default 12)",
-			!exists, !rolling, 0, 0, !rolling, blank, 24, default12, cfg{0, rolling, 0, 24}, !returnsError},
+			!exists, !rolling, 0, 0, !rolling, blank, 24, default12, cfg{12, rolling, 0, 24}, !returnsError},
 
 		tc{"rita import --chunk 5  (default 12)",
-			!exists, !rolling, 0, 0, !rolling, 5, blank, default12, cfg{0, rolling, 5, 12}, !returnsError},
+			!exists, !rolling, 0, 0, !rolling, 5, blank, default12, cfg{12, rolling, 5, 12}, !returnsError},
 
 		tc{"rita import --chunk 12 (default 12)",
-			!exists, !rolling, 0, 0, !rolling, 12, blank, default12, cfg{0, rolling, 12, 12}, returnsError},
+			!exists, !rolling, 0, 0, !rolling, 12, blank, default12, cfg{12, rolling, 12, 12}, returnsError},
 
 		tc{"rita import --chunk 12 (default 24)",
-			!exists, !rolling, 0, 0, !rolling, 12, blank, default24, cfg{0, rolling, 12, 24}, !returnsError},
+			!exists, !rolling, 0, 0, !rolling, 12, blank, default24, cfg{24, rolling, 12, 24}, !returnsError},
 
 		tc{"rita import --chunk 12 --numchunks 24 (default 12)",
-			!exists, !rolling, 0, 0, !rolling, 12, 24, default12, cfg{0, rolling, 12, 24}, !returnsError},
+			!exists, !rolling, 0, 0, !rolling, 12, 24, default12, cfg{12, rolling, 12, 24}, !returnsError},
 
 		tc{"rita import --chunk -2 (default 12)",
-			!exists, !rolling, 0, 0, !rolling, -2, blank, default12, cfg{0, rolling, -2, 12}, returnsError},
+			!exists, !rolling, 0, 0, !rolling, -2, blank, default12, cfg{12, rolling, -2, 12}, returnsError},
 
 		tc{"rita import --numchunks -2 (default 12)",
-			!exists, !rolling, 0, 0, !rolling, blank, -2, default12, cfg{0, rolling, 0, -2}, returnsError},
+			!exists, !rolling, 0, 0, !rolling, blank, -2, default12, cfg{12, rolling, 0, -2}, returnsError},
 
 		// existing database scenarios
 
 		// non-rolling, current chunk 0, total chunks 1
 		tc{"rita import",
-			exists, !rolling, 0, 1, !rolling, blank, blank, default12, cfg{0, rolling, 1, 12}, !returnsError},
+			exists, !rolling, 0, 1, !rolling, blank, blank, default12, cfg{12, !rolling, 1, 12}, !returnsError},
 
 		tc{"rita import --rolling",
-			exists, !rolling, 0, 1, rolling, blank, blank, default12, cfg{0, rolling, 1, 12}, !returnsError},
+			exists, !rolling, 0, 1, rolling, blank, blank, default12, cfg{12, rolling, 1, 12}, !returnsError},
 
 		tc{"rita import --rolling --chunk 0 --numchunks 24",
-			exists, !rolling, 0, 1, rolling, 0, 24, default12, cfg{0, rolling, 0, 24}, !returnsError},
+			exists, !rolling, 0, 1, rolling, 0, 24, default12, cfg{12, rolling, 0, 24}, !returnsError},
 
 		tc{"rita import --numchunks 24",
-			exists, !rolling, 0, 1, !rolling, blank, 24, default12, cfg{0, rolling, 1, 24}, !returnsError},
+			exists, !rolling, 0, 1, !rolling, blank, 24, default12, cfg{12, rolling, 1, 24}, !returnsError},
 
 		tc{"rita import --chunk 5 (default 12)",
-			exists, !rolling, 0, 1, !rolling, 5, blank, default12, cfg{0, rolling, 5, 12}, !returnsError},
+			exists, !rolling, 0, 1, !rolling, 5, blank, default12, cfg{12, rolling, 5, 12}, !returnsError},
 
 		tc{"rita import --chunk 12 (default 12)",
-			exists, !rolling, 0, 1, !rolling, 12, blank, default12, cfg{0, rolling, 12, 12}, returnsError},
+			exists, !rolling, 0, 1, !rolling, 12, blank, default12, cfg{12, rolling, 12, 12}, returnsError},
 
 		tc{"rita import --chunk 12 (default 24)",
-			exists, !rolling, 0, 1, !rolling, 12, blank, default24, cfg{0, rolling, 12, 24}, !returnsError},
+			exists, !rolling, 0, 1, !rolling, 12, blank, default24, cfg{24, rolling, 12, 24}, !returnsError},
 
 		tc{"rita import --chunk 12 --numchunks 24",
-			exists, !rolling, 0, 1, !rolling, 12, 24, default12, cfg{0, rolling, 12, 24}, !returnsError},
+			exists, !rolling, 0, 1, !rolling, 12, 24, default12, cfg{12, rolling, 12, 24}, !returnsError},
 
 		tc{"rita import --chunk -2",
-			exists, !rolling, 0, 1, !rolling, -2, blank, default12, cfg{0, rolling, -2, 12}, returnsError},
+			exists, !rolling, 0, 1, !rolling, -2, blank, default12, cfg{12, rolling, -2, 12}, returnsError},
 
 		tc{"rita import --numchunks -2",
-			exists, !rolling, 0, 1, !rolling, blank, -2, default12, cfg{0, rolling, 1, -2}, returnsError},
+			exists, !rolling, 0, 1, !rolling, blank, -2, default12, cfg{12, rolling, 1, -2}, returnsError},
 
 		// rolling, current chunk 1, total chunks 12
 		tc{"rita import",
-			exists, rolling, 1, 12, !rolling, blank, blank, default12, cfg{0, rolling, 2, 12}, !returnsError},
+			exists, rolling, 1, 12, !rolling, blank, blank, default12, cfg{12, rolling, 2, 12}, !returnsError},
 
 		tc{"rita import --rolling",
-			exists, rolling, 1, 12, rolling, blank, blank, default12, cfg{0, rolling, 2, 12}, !returnsError},
+			exists, rolling, 1, 12, rolling, blank, blank, default12, cfg{12, rolling, 2, 12}, !returnsError},
 
 		tc{"rita import --rolling --chunk 0 --numchunks 24",
-			exists, rolling, 1, 12, rolling, 0, 24, default12, cfg{0, rolling, 0, 24}, !returnsError},
+			exists, rolling, 1, 12, rolling, 0, 24, default12, cfg{12, rolling, 0, 24}, !returnsError},
 
 		tc{"rita import --numchunks 24",
-			exists, rolling, 1, 12, !rolling, blank, 24, default12, cfg{0, rolling, 2, 24}, !returnsError},
+			exists, rolling, 1, 12, !rolling, blank, 24, default12, cfg{12, rolling, 2, 24}, !returnsError},
 
 		tc{"rita import --chunk 5 (default 12)",
-			exists, rolling, 1, 12, !rolling, 5, blank, default12, cfg{0, rolling, 5, 12}, !returnsError},
+			exists, rolling, 1, 12, !rolling, 5, blank, default12, cfg{12, rolling, 5, 12}, !returnsError},
 
 		tc{"rita import --chunk 12 (default 12)",
-			exists, rolling, 1, 12, !rolling, 12, blank, default12, cfg{0, rolling, 12, 12}, returnsError},
+			exists, rolling, 1, 12, !rolling, 12, blank, default12, cfg{12, rolling, 12, 12}, returnsError},
 
 		tc{"rita import --chunk 12 (default 24)",
-			exists, rolling, 1, 12, !rolling, 12, blank, default24, cfg{0, rolling, 12, 12}, returnsError},
+			exists, rolling, 1, 12, !rolling, 12, blank, default24, cfg{24, rolling, 12, 12}, returnsError},
 
 		tc{"rita import --chunk 12 --numchunks 24",
-			exists, rolling, 1, 12, !rolling, 12, 24, default12, cfg{0, rolling, 12, 24}, !returnsError},
+			exists, rolling, 1, 12, !rolling, 12, 24, default12, cfg{12, rolling, 12, 24}, !returnsError},
 
 		tc{"rita import --chunk -2",
-			exists, rolling, 1, 12, !rolling, -2, blank, default12, cfg{0, rolling, -2, 12}, returnsError},
+			exists, rolling, 1, 12, !rolling, -2, blank, default12, cfg{12, rolling, -2, 12}, returnsError},
 
 		tc{"rita import --numchunks -2",
-			exists, rolling, 1, 12, !rolling, blank, -2, default12, cfg{0, rolling, 0, -2}, returnsError},
+			exists, rolling, 1, 12, !rolling, blank, -2, default12, cfg{12, rolling, 0, -2}, returnsError},
 
 		// rolling, current chunk 11, total chunks 12
 		tc{"rita import",
-			exists, rolling, 11, 12, !rolling, blank, blank, default12, cfg{0, rolling, 0, 12}, !returnsError},
+			exists, rolling, 11, 12, !rolling, blank, blank, default12, cfg{12, rolling, 0, 12}, !returnsError},
 
 		tc{"rita import --rolling",
-			exists, rolling, 11, 12, rolling, blank, blank, default12, cfg{0, rolling, 0, 12}, !returnsError},
+			exists, rolling, 11, 12, rolling, blank, blank, default12, cfg{12, rolling, 0, 12}, !returnsError},
 
 		tc{"rita import --rolling --chunk 0 --numchunks 24",
-			exists, rolling, 11, 12, rolling, 0, 24, default12, cfg{0, rolling, 0, 24}, !returnsError},
+			exists, rolling, 11, 12, rolling, 0, 24, default12, cfg{12, rolling, 0, 24}, !returnsError},
 
 		tc{"rita import --numchunks 24",
-			exists, rolling, 11, 12, !rolling, blank, 24, default12, cfg{0, rolling, 12, 24}, !returnsError},
+			exists, rolling, 11, 12, !rolling, blank, 24, default12, cfg{12, rolling, 12, 24}, !returnsError},
 
 		tc{"rita import --chunk 5 (default 12)",
-			exists, rolling, 11, 12, !rolling, 5, blank, default12, cfg{0, rolling, 5, 12}, !returnsError},
+			exists, rolling, 11, 12, !rolling, 5, blank, default12, cfg{12, rolling, 5, 12}, !returnsError},
 
 		tc{"rita import --chunk 12 (default 12)",
-			exists, rolling, 11, 12, !rolling, 12, blank, default12, cfg{0, rolling, 12, 12}, returnsError},
+			exists, rolling, 11, 12, !rolling, 12, blank, default12, cfg{12, rolling, 12, 12}, returnsError},
 
 		tc{"rita import --chunk 12 (default 24)",
-			exists, rolling, 11, 12, !rolling, 12, blank, default24, cfg{0, rolling, 12, 12}, returnsError},
+			exists, rolling, 11, 12, !rolling, 12, blank, default24, cfg{24, rolling, 12, 12}, returnsError},
 
 		tc{"rita import --chunk 12 --numchunks 24",
-			exists, rolling, 11, 12, !rolling, 12, 24, default12, cfg{0, rolling, 12, 24}, !returnsError},
+			exists, rolling, 11, 12, !rolling, 12, 24, default12, cfg{12, rolling, 12, 24}, !returnsError},
 
 		// rolling, current chunk 11, total chunks 24
 		tc{"rita import",
-			exists, rolling, 11, 24, !rolling, blank, blank, default12, cfg{0, rolling, 12, 24}, !returnsError},
+			exists, rolling, 11, 24, !rolling, blank, blank, default12, cfg{12, rolling, 12, 24}, !returnsError},
 
 		tc{"rita import --rolling",
-			exists, rolling, 11, 24, rolling, blank, blank, default12, cfg{0, rolling, 12, 24}, !returnsError},
+			exists, rolling, 11, 24, rolling, blank, blank, default12, cfg{12, rolling, 12, 24}, !returnsError},
 
 		tc{"rita import --rolling --chunk 0 --numchunks 24",
-			exists, rolling, 11, 24, rolling, 0, 24, default12, cfg{0, rolling, 0, 24}, !returnsError},
+			exists, rolling, 11, 24, rolling, 0, 24, default12, cfg{12, rolling, 0, 24}, !returnsError},
 
 		tc{"rita import --numchunks 12",
-			exists, rolling, 11, 24, !rolling, blank, 12, default12, cfg{0, rolling, 0, 12}, returnsError},
+			exists, rolling, 11, 24, !rolling, blank, 12, default12, cfg{12, rolling, 0, 12}, returnsError},
 
 		tc{"rita import --chunk 12 --numchunks 12",
-			exists, rolling, 11, 24, !rolling, 12, 12, default12, cfg{0, rolling, 12, 12}, returnsError},
+			exists, rolling, 11, 24, !rolling, 12, 12, default12, cfg{12, rolling, 12, 12}, returnsError},
 
 		tc{"rita import --chunk 13 (default 12)",
-			exists, rolling, 11, 24, !rolling, 13, blank, default12, cfg{0, rolling, 13, 24}, !returnsError},
+			exists, rolling, 11, 24, !rolling, 13, blank, default12, cfg{12, rolling, 13, 24}, !returnsError},
 	}
 
 	// runner for the test table above
 	for _, testCase := range testCases {
 		actual, err := setRolling(
 			testCase.dbExists, testCase.dbIsRolling, testCase.dbCurrChunk, testCase.dbTotalChunks,
-			testCase.userIsRolling,	testCase.userCurrChunk,	testCase.userTotalChunks, testCase.cfgDefaultChunks,
+			testCase.userIsRolling, testCase.userCurrChunk, testCase.userTotalChunks, testCase.cfgDefaultChunks,
 		)
 
 		// Construct a message that will help pinpoint which test failed

--- a/commands/import_test.go
+++ b/commands/import_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/activecm/rita/config"
 )
 
-func TestSetRolling(t *testing.T) {
+func TestParseFlags(t *testing.T) {
 	type cfg = config.RollingStaticCfg // including the definition here for reference:
 	// 	DefaultChunks int `yaml:"DefaultChunks" default:"12"`
 	// 	Rolling       bool
@@ -26,6 +26,7 @@ func TestSetRolling(t *testing.T) {
 		userCurrChunk    int
 		userTotalChunks  int
 		cfgDefaultChunks int
+		deleteOldData    bool
 		expected         cfg
 		err              bool
 	}
@@ -36,6 +37,7 @@ func TestSetRolling(t *testing.T) {
 	// these are used to help make the test table below (a little) more readable
 	const exists bool = true
 	const rolling bool = true
+	const delete bool = true
 	const returnsError bool = true
 	const default12 int = 12
 	const default24 int = 24
@@ -44,149 +46,210 @@ func TestSetRolling(t *testing.T) {
 		// new database scenarios
 
 		tc{"rita import (default 12)",
-			!exists, !rolling, 0, 0, !rolling, blank, blank, default12, cfg{12, !rolling, 0, 1}, !returnsError},
+			!exists, !rolling, 0, 0, !rolling, blank, blank, default12, !delete, cfg{12, !rolling, 0, 1}, !returnsError},
 
 		tc{"rita import --rolling (default 12)",
-			!exists, !rolling, 0, 0, rolling, blank, blank, default12, cfg{12, rolling, 0, 12}, !returnsError},
+			!exists, !rolling, 0, 0, rolling, blank, blank, default12, !delete, cfg{12, rolling, 0, 12}, !returnsError},
 
 		tc{"rita import --rolling --chunk 0 --numchunks 24 (default 12)",
-			!exists, !rolling, 0, 0, rolling, 0, 24, default12, cfg{12, rolling, 0, 24}, !returnsError},
+			!exists, !rolling, 0, 0, rolling, 0, 24, default12, !delete, cfg{12, rolling, 0, 24}, !returnsError},
 
 		tc{"rita import --numchunks 24 (default 12)",
-			!exists, !rolling, 0, 0, !rolling, blank, 24, default12, cfg{12, rolling, 0, 24}, !returnsError},
+			!exists, !rolling, 0, 0, !rolling, blank, 24, default12, !delete, cfg{12, rolling, 0, 24}, !returnsError},
 
 		tc{"rita import --chunk 5  (default 12)",
-			!exists, !rolling, 0, 0, !rolling, 5, blank, default12, cfg{12, rolling, 5, 12}, !returnsError},
+			!exists, !rolling, 0, 0, !rolling, 5, blank, default12, !delete, cfg{12, rolling, 5, 12}, !returnsError},
 
 		tc{"rita import --chunk 12 (default 12)",
-			!exists, !rolling, 0, 0, !rolling, 12, blank, default12, cfg{12, rolling, 12, 12}, returnsError},
+			!exists, !rolling, 0, 0, !rolling, 12, blank, default12, !delete, cfg{12, rolling, 12, 12}, returnsError},
 
 		tc{"rita import --chunk 12 (default 24)",
-			!exists, !rolling, 0, 0, !rolling, 12, blank, default24, cfg{24, rolling, 12, 24}, !returnsError},
+			!exists, !rolling, 0, 0, !rolling, 12, blank, default24, !delete, cfg{24, rolling, 12, 24}, !returnsError},
 
 		tc{"rita import --chunk 12 --numchunks 24 (default 12)",
-			!exists, !rolling, 0, 0, !rolling, 12, 24, default12, cfg{12, rolling, 12, 24}, !returnsError},
+			!exists, !rolling, 0, 0, !rolling, 12, 24, default12, !delete, cfg{12, rolling, 12, 24}, !returnsError},
 
 		tc{"rita import --chunk -2 (default 12)",
-			!exists, !rolling, 0, 0, !rolling, -2, blank, default12, cfg{12, rolling, -2, 12}, returnsError},
+			!exists, !rolling, 0, 0, !rolling, -2, blank, default12, !delete, cfg{}, returnsError},
 
 		tc{"rita import --numchunks -2 (default 12)",
-			!exists, !rolling, 0, 0, !rolling, blank, -2, default12, cfg{12, rolling, 0, -2}, returnsError},
+			!exists, !rolling, 0, 0, !rolling, blank, -2, default12, !delete, cfg{}, returnsError},
+
+		tc{"rita import --delete (default 12)",
+			!exists, !rolling, 0, 0, !rolling, blank, blank, default12, delete, cfg{12, !rolling, 0, 1}, !returnsError},
+
+		tc{"rita import --delete --rolling (default 12)",
+			!exists, !rolling, 0, 0, rolling, blank, blank, default12, delete, cfg{12, rolling, 0, 12}, !returnsError},
+
+		tc{"rita import --delete --rolling --chunk 0 --numchunks 24 (default 12)",
+			!exists, !rolling, 0, 0, rolling, 0, 24, default12, delete, cfg{12, rolling, 0, 24}, !returnsError},
+
+		tc{"rita import --delete --chunk 5  (default 12)",
+			!exists, !rolling, 0, 0, !rolling, 5, blank, default12, delete, cfg{12, rolling, 5, 12}, !returnsError},
 
 		// existing database scenarios
 
 		// non-rolling, current chunk 0, total chunks 1
 		tc{"rita import",
-			exists, !rolling, 0, 1, !rolling, blank, blank, default12, cfg{12, !rolling, 1, 12}, !returnsError},
+			exists, !rolling, 0, 1, !rolling, blank, blank, default12, !delete, cfg{}, returnsError},
 
 		tc{"rita import --rolling",
-			exists, !rolling, 0, 1, rolling, blank, blank, default12, cfg{12, rolling, 1, 12}, !returnsError},
+			exists, !rolling, 0, 1, rolling, blank, blank, default12, !delete, cfg{12, rolling, 1, 12}, !returnsError},
 
 		tc{"rita import --rolling --chunk 0 --numchunks 24",
-			exists, !rolling, 0, 1, rolling, 0, 24, default12, cfg{12, rolling, 0, 24}, !returnsError},
+			exists, !rolling, 0, 1, rolling, 0, 24, default12, !delete, cfg{12, rolling, 0, 24}, !returnsError},
 
 		tc{"rita import --numchunks 24",
-			exists, !rolling, 0, 1, !rolling, blank, 24, default12, cfg{12, rolling, 1, 24}, !returnsError},
+			exists, !rolling, 0, 1, !rolling, blank, 24, default12, !delete, cfg{12, rolling, 1, 24}, !returnsError},
 
 		tc{"rita import --chunk 5 (default 12)",
-			exists, !rolling, 0, 1, !rolling, 5, blank, default12, cfg{12, rolling, 5, 12}, !returnsError},
+			exists, !rolling, 0, 1, !rolling, 5, blank, default12, !delete, cfg{12, rolling, 5, 12}, !returnsError},
 
 		tc{"rita import --chunk 12 (default 12)",
-			exists, !rolling, 0, 1, !rolling, 12, blank, default12, cfg{12, rolling, 12, 12}, returnsError},
+			exists, !rolling, 0, 1, !rolling, 12, blank, default12, !delete, cfg{12, rolling, 12, 12}, returnsError},
 
 		tc{"rita import --chunk 12 (default 24)",
-			exists, !rolling, 0, 1, !rolling, 12, blank, default24, cfg{24, rolling, 12, 24}, !returnsError},
+			exists, !rolling, 0, 1, !rolling, 12, blank, default24, !delete, cfg{24, rolling, 12, 24}, !returnsError},
 
 		tc{"rita import --chunk 12 --numchunks 24",
-			exists, !rolling, 0, 1, !rolling, 12, 24, default12, cfg{12, rolling, 12, 24}, !returnsError},
+			exists, !rolling, 0, 1, !rolling, 12, 24, default12, !delete, cfg{12, rolling, 12, 24}, !returnsError},
 
 		tc{"rita import --chunk -2",
-			exists, !rolling, 0, 1, !rolling, -2, blank, default12, cfg{12, rolling, -2, 12}, returnsError},
+			exists, !rolling, 0, 1, !rolling, -2, blank, default12, !delete, cfg{}, returnsError},
 
 		tc{"rita import --numchunks -2",
-			exists, !rolling, 0, 1, !rolling, blank, -2, default12, cfg{12, rolling, 1, -2}, returnsError},
+			exists, !rolling, 0, 1, !rolling, blank, -2, default12, !delete, cfg{}, returnsError},
+
+		tc{"rita import --delete (default 12)",
+			exists, !rolling, 0, 1, !rolling, blank, blank, default12, delete, cfg{12, !rolling, 0, 1}, !returnsError},
+
+		tc{"rita import --delete --rolling (default 12)",
+			exists, !rolling, 0, 1, rolling, blank, blank, default12, delete, cfg{12, rolling, 0, 12}, !returnsError},
+
+		tc{"rita import --delete --chunk 5 (default 12)",
+			exists, !rolling, 0, 1, !rolling, 5, blank, default12, delete, cfg{12, rolling, 5, 12}, !returnsError},
+
+		tc{"rita import --delete --rolling --chunk 0 --numchunks 24 (default 12)",
+			exists, !rolling, 0, 1, rolling, 0, 24, default12, delete, cfg{12, rolling, 0, 24}, !returnsError},
 
 		// rolling, current chunk 1, total chunks 12
 		tc{"rita import",
-			exists, rolling, 1, 12, !rolling, blank, blank, default12, cfg{12, rolling, 2, 12}, !returnsError},
+			exists, rolling, 1, 12, !rolling, blank, blank, default12, !delete, cfg{12, rolling, 2, 12}, !returnsError},
 
 		tc{"rita import --rolling",
-			exists, rolling, 1, 12, rolling, blank, blank, default12, cfg{12, rolling, 2, 12}, !returnsError},
+			exists, rolling, 1, 12, rolling, blank, blank, default12, !delete, cfg{12, rolling, 2, 12}, !returnsError},
 
 		tc{"rita import --rolling --chunk 0 --numchunks 24",
-			exists, rolling, 1, 12, rolling, 0, 24, default12, cfg{12, rolling, 0, 24}, !returnsError},
+			exists, rolling, 1, 12, rolling, 0, 24, default12, !delete, cfg{12, rolling, 0, 24}, !returnsError},
 
 		tc{"rita import --numchunks 24",
-			exists, rolling, 1, 12, !rolling, blank, 24, default12, cfg{12, rolling, 2, 24}, !returnsError},
+			exists, rolling, 1, 12, !rolling, blank, 24, default12, !delete, cfg{12, rolling, 2, 24}, !returnsError},
 
 		tc{"rita import --chunk 5 (default 12)",
-			exists, rolling, 1, 12, !rolling, 5, blank, default12, cfg{12, rolling, 5, 12}, !returnsError},
+			exists, rolling, 1, 12, !rolling, 5, blank, default12, !delete, cfg{12, rolling, 5, 12}, !returnsError},
 
 		tc{"rita import --chunk 12 (default 12)",
-			exists, rolling, 1, 12, !rolling, 12, blank, default12, cfg{12, rolling, 12, 12}, returnsError},
+			exists, rolling, 1, 12, !rolling, 12, blank, default12, !delete, cfg{}, returnsError},
 
 		tc{"rita import --chunk 12 (default 24)",
-			exists, rolling, 1, 12, !rolling, 12, blank, default24, cfg{24, rolling, 12, 12}, returnsError},
+			exists, rolling, 1, 12, !rolling, 12, blank, default24, !delete, cfg{}, returnsError},
 
 		tc{"rita import --chunk 12 --numchunks 24",
-			exists, rolling, 1, 12, !rolling, 12, 24, default12, cfg{12, rolling, 12, 24}, !returnsError},
+			exists, rolling, 1, 12, !rolling, 12, 24, default12, !delete, cfg{12, rolling, 12, 24}, !returnsError},
 
 		tc{"rita import --chunk -2",
-			exists, rolling, 1, 12, !rolling, -2, blank, default12, cfg{12, rolling, -2, 12}, returnsError},
+			exists, rolling, 1, 12, !rolling, -2, blank, default12, !delete, cfg{}, returnsError},
 
 		tc{"rita import --numchunks -2",
-			exists, rolling, 1, 12, !rolling, blank, -2, default12, cfg{12, rolling, 0, -2}, returnsError},
+			exists, rolling, 1, 12, !rolling, blank, -2, default12, !delete, cfg{}, returnsError},
+
+		tc{"rita import --delete (default 12)",
+			exists, rolling, 1, 12, !rolling, blank, blank, default12, delete, cfg{12, rolling, 1, 12}, !returnsError},
+
+		tc{"rita import --delete --rolling (default 12)",
+			exists, rolling, 1, 12, !rolling, blank, blank, default12, delete, cfg{12, rolling, 1, 12}, !returnsError},
+
+		tc{"rita import --delete --chunk 5 (default 12)",
+			exists, rolling, 1, 12, !rolling, 5, blank, default12, delete, cfg{12, rolling, 5, 12}, !returnsError},
+
+		tc{"rita import --delete --rolling --chunk 0 --numchunks 24 (default 12)",
+			exists, rolling, 1, 12, rolling, 0, 24, default12, delete, cfg{12, rolling, 0, 24}, !returnsError},
 
 		// rolling, current chunk 11, total chunks 12
 		tc{"rita import",
-			exists, rolling, 11, 12, !rolling, blank, blank, default12, cfg{12, rolling, 0, 12}, !returnsError},
+			exists, rolling, 11, 12, !rolling, blank, blank, default12, !delete, cfg{12, rolling, 0, 12}, !returnsError},
 
 		tc{"rita import --rolling",
-			exists, rolling, 11, 12, rolling, blank, blank, default12, cfg{12, rolling, 0, 12}, !returnsError},
+			exists, rolling, 11, 12, rolling, blank, blank, default12, !delete, cfg{12, rolling, 0, 12}, !returnsError},
 
 		tc{"rita import --rolling --chunk 0 --numchunks 24",
-			exists, rolling, 11, 12, rolling, 0, 24, default12, cfg{12, rolling, 0, 24}, !returnsError},
+			exists, rolling, 11, 12, rolling, 0, 24, default12, !delete, cfg{12, rolling, 0, 24}, !returnsError},
 
 		tc{"rita import --numchunks 24",
-			exists, rolling, 11, 12, !rolling, blank, 24, default12, cfg{12, rolling, 12, 24}, !returnsError},
+			exists, rolling, 11, 12, !rolling, blank, 24, default12, !delete, cfg{12, rolling, 12, 24}, !returnsError},
 
 		tc{"rita import --chunk 5 (default 12)",
-			exists, rolling, 11, 12, !rolling, 5, blank, default12, cfg{12, rolling, 5, 12}, !returnsError},
+			exists, rolling, 11, 12, !rolling, 5, blank, default12, !delete, cfg{12, rolling, 5, 12}, !returnsError},
 
 		tc{"rita import --chunk 12 (default 12)",
-			exists, rolling, 11, 12, !rolling, 12, blank, default12, cfg{12, rolling, 12, 12}, returnsError},
+			exists, rolling, 11, 12, !rolling, 12, blank, default12, !delete, cfg{}, returnsError},
 
 		tc{"rita import --chunk 12 (default 24)",
-			exists, rolling, 11, 12, !rolling, 12, blank, default24, cfg{24, rolling, 12, 12}, returnsError},
+			exists, rolling, 11, 12, !rolling, 12, blank, default24, !delete, cfg{}, returnsError},
 
 		tc{"rita import --chunk 12 --numchunks 24",
-			exists, rolling, 11, 12, !rolling, 12, 24, default12, cfg{12, rolling, 12, 24}, !returnsError},
+			exists, rolling, 11, 12, !rolling, 12, 24, default12, !delete, cfg{12, rolling, 12, 24}, !returnsError},
+
+		tc{"rita import --delete (default 12)",
+			exists, rolling, 11, 12, !rolling, blank, blank, default12, delete, cfg{12, rolling, 11, 12}, !returnsError},
+
+		tc{"rita import --delete --rolling (default 12)",
+			exists, rolling, 11, 12, !rolling, blank, blank, default12, delete, cfg{12, rolling, 11, 12}, !returnsError},
+
+		tc{"rita import --delete --chunk 5 (default 12)",
+			exists, rolling, 11, 12, !rolling, 5, blank, default12, delete, cfg{12, rolling, 5, 12}, !returnsError},
+
+		tc{"rita import --delete --rolling --chunk 0 --numchunks 24 (default 12)",
+			exists, rolling, 11, 12, rolling, 0, 24, default12, delete, cfg{12, rolling, 0, 24}, !returnsError},
 
 		// rolling, current chunk 11, total chunks 24
 		tc{"rita import",
-			exists, rolling, 11, 24, !rolling, blank, blank, default12, cfg{12, rolling, 12, 24}, !returnsError},
+			exists, rolling, 11, 24, !rolling, blank, blank, default12, !delete, cfg{12, rolling, 12, 24}, !returnsError},
 
 		tc{"rita import --rolling",
-			exists, rolling, 11, 24, rolling, blank, blank, default12, cfg{12, rolling, 12, 24}, !returnsError},
+			exists, rolling, 11, 24, rolling, blank, blank, default12, !delete, cfg{12, rolling, 12, 24}, !returnsError},
 
 		tc{"rita import --rolling --chunk 0 --numchunks 24",
-			exists, rolling, 11, 24, rolling, 0, 24, default12, cfg{12, rolling, 0, 24}, !returnsError},
+			exists, rolling, 11, 24, rolling, 0, 24, default12, !delete, cfg{12, rolling, 0, 24}, !returnsError},
 
 		tc{"rita import --numchunks 12",
-			exists, rolling, 11, 24, !rolling, blank, 12, default12, cfg{12, rolling, 0, 12}, returnsError},
+			exists, rolling, 11, 24, !rolling, blank, 12, default12, !delete, cfg{}, returnsError},
 
 		tc{"rita import --chunk 12 --numchunks 12",
-			exists, rolling, 11, 24, !rolling, 12, 12, default12, cfg{12, rolling, 12, 12}, returnsError},
+			exists, rolling, 11, 24, !rolling, 12, 12, default12, !delete, cfg{}, returnsError},
 
 		tc{"rita import --chunk 13 (default 12)",
-			exists, rolling, 11, 24, !rolling, 13, blank, default12, cfg{12, rolling, 13, 24}, !returnsError},
+			exists, rolling, 11, 24, !rolling, 13, blank, default12, !delete, cfg{12, rolling, 13, 24}, !returnsError},
+
+		tc{"rita import --delete (default 12)",
+			exists, rolling, 11, 24, !rolling, blank, blank, default12, delete, cfg{12, rolling, 11, 24}, !returnsError},
+
+		tc{"rita import --delete --rolling (default 12)",
+			exists, rolling, 11, 12, !rolling, blank, blank, default12, delete, cfg{12, rolling, 11, 12}, !returnsError},
+
+		tc{"rita import --delete --chunk 5 (default 12)",
+			exists, rolling, 11, 24, !rolling, 5, blank, default12, !delete, cfg{12, rolling, 5, 24}, !returnsError},
+
+		tc{"rita import --delete --rolling --chunk 0 --numchunks 24 (default 12)",
+			exists, rolling, 11, 24, rolling, 0, 24, default12, !delete, cfg{12, rolling, 0, 24}, !returnsError},
 	}
 
 	// runner for the test table above
 	for _, testCase := range testCases {
-		actual, err := setRolling(
+		actual, err := parseFlags(
 			testCase.dbExists, testCase.dbIsRolling, testCase.dbCurrChunk, testCase.dbTotalChunks,
 			testCase.userIsRolling, testCase.userCurrChunk, testCase.userTotalChunks, testCase.cfgDefaultChunks,
+			testCase.deleteOldData,
 		)
 
 		// Construct a message that will help pinpoint which test failed

--- a/config/static.go
+++ b/config/static.go
@@ -59,7 +59,7 @@ type (
 
 	//RollingStaticCfg controls the rolling database settings
 	RollingStaticCfg struct {
-		DefaultChunks int `yaml:"DefaultChunks" default:"12"`
+		DefaultChunks int `yaml:"DefaultChunks" default:"24"`
 		Rolling       bool
 		CurrentChunk  int
 		TotalChunks   int

--- a/parser/fileparsetypes/fileparsetypes.go
+++ b/parser/fileparsetypes/fileparsetypes.go
@@ -32,6 +32,7 @@ type IndexedFile struct {
 	Hash             string        `bson:"hash"`
 	TargetCollection string        `bson:"collection"`
 	TargetDatabase   string        `bson:"database"`
+	CID              int           `bson:"cid"`
 	ParseTime        time.Time     `bson:"time_complete"`
 	header           *BroHeader
 	broDataFactory   func() pt.BroData

--- a/parser/fsimporter.go
+++ b/parser/fsimporter.go
@@ -77,18 +77,12 @@ func (fs *FSImporter) GetInternalSubnets() []*net.IPNet {
 	return fs.internal
 }
 
-func (fs *FSImporter) CollectFileDetails() ([]*fpt.IndexedFile, error) {
+func (fs *FSImporter) CollectFileDetails() []*fpt.IndexedFile {
 	// find all of the potential bro log paths
 	files := readFiles(fs.importFiles, fs.res.Log)
 
 	// hash the files and get their stats
-	indexedFiles := indexFiles(files, fs.indexingThreads, fs.res)
-
-	// if no compatible files for import were found, handle error
-	if !(len(indexedFiles) > 0) {
-		return indexedFiles, fmt.Errorf("No compatible log files found")
-	}
-	return indexedFiles, nil
+	return indexFiles(files, fs.indexingThreads, fs.res)
 }
 
 //Run starts the importing

--- a/parser/indexedfile.go
+++ b/parser/indexedfile.go
@@ -83,6 +83,7 @@ func newIndexedFile(filePath string, res *resources.Resources) (*fpt.IndexedFile
 	}
 
 	toReturn.TargetDatabase = res.DB.GetSelectedDB()
+	toReturn.CID = res.Config.S.Rolling.CurrentChunk
 
 	fileHandle.Close()
 	return toReturn, nil

--- a/parser/indexedfile.go
+++ b/parser/indexedfile.go
@@ -139,7 +139,16 @@ func indexFiles(files []string, indexingThreads int, res *resources.Resources) [
 	}
 
 	indexingWG.Wait()
-	return output
+
+	// remove all nil values from the slice
+	indexedFiles := make([]*fpt.IndexedFile, 0, len(output))
+	for _, file := range output {
+		if file != nil {
+			indexedFiles = append(indexedFiles, file)
+		}
+	}
+
+	return indexedFiles
 }
 
 //removeOldFilesFromIndex checks all indexedFiles passed in to ensure
@@ -157,11 +166,6 @@ func removeOldFilesFromIndex(indexedFiles []*fpt.IndexedFile,
 	}
 
 	for _, newFile := range indexedFiles {
-		if newFile == nil {
-			//this file was errored on earlier, i.e. we didn't find a tgtDB etc.
-			continue
-		}
-
 		have := false
 		for _, oldFile := range oldFiles {
 			if oldFile.Hash == newFile.Hash {


### PR DESCRIPTION
This PR introduces the `--delete` flag to the `rita import` command. This flag deletes any existing data in the target import location before importing new data.

If the target database is not a rolling database, the flag is used as:
```
rita import --delete /path/to/file_or_dir_1 [/path/to/file_or_dir_n ...] target_database
```

If the target database is a rolling database, the CID for the chunk to be replaced ~must~ may be specified:
```
rita import --delete -CC N /path/to/file_or_dir_1 [/path/to/file_or_dir_n ...] target_database
```

If the CID is not specified and the target database is a rolling database, the latest chunk is replaced:
```
rita import --delete --rolling /path/to/file_or_dir_1 [/path/to/file_or_dir_n ...] target_database
```

The command will fail on existing rolling databases. This is because the CID for each indexed file in the files collection is not currently tracked. However, going forward this will not be a problem.

I tested this PR using the `rita-diff.py` script in the old ipfix-rita repository. I created a rolling database with four chunks, copied the database to a clean, backup database, and re-imported each chunk. Finally, I ran `rita-diff.py` against the datasets. The script revealed minor inconsistencies in the beacons results in the `ts.conns_score` field, but this inconsistency was tracked down to code outside of this PR. Once those inconsistencies were accounted for, there were none.