### PR TITLE
Fix JA3 Installation

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -223,7 +223,7 @@ __install_ja3() {
 
 	for one_file in __load__.bro intel_ja3.bro ja3.bro ja3s.bro ; do
 		if [ ! -e $local_path/ja3/$one_file ]; then
-			sudo curl -sSL "https://raw.githubusercontent.com/salesforce/ja3/master/bro//$one_file" -o "$local_path/ja3/$one_file"
+			sudo curl -sSL "https://raw.githubusercontent.com/salesforce/ja3/cb29184df7949743c64fcb190c902dfe72523e38/bro//$one_file" -o "$local_path/ja3/$one_file"
 		fi
 	done
 


### PR DESCRIPTION
On November 15, 2019, the JA3 installation routine broke in the RITA install script. As part of the bro -> zeek rebrand, salesforce changed their bro scripts to zeek scripts. This broke the download urls in the install script. The install fails silently, leaving the message `404: Not Found` in each of the downloaded files. 

Running bro with broken files and the local policy results in the following error:
```
error in /opt/bro/share/bro/site/./ja3/__load__.bro, line 1: syntax error, at or near ":"
```

The following files are affected:
- `/opt/bro/share/bro/site/ja3/__load__.bro`
- `/opt/bro/share/bro/site/ja3/intel_ja3.bro`
- `/opt/bro/share/bro/site/ja3/ja3.bro`
- `/opt/bro/share/bro/site/ja3/ja3s.bro`

I've pinned the download links to the pre-rename commit in this PR. Future work should be done to convert the installer to using the zeek name/ zeek scripts.

To fix this issue on an affected system, run the following shell snippet:

```
local_path=/opt/bro/share/bro/site;
for one_file in __load__.bro intel_ja3.bro ja3.bro ja3s.bro ; do
sudo curl -sSL "https://raw.githubusercontent.com/salesforce/ja3/cb29184df7949743c64fcb190c902dfe72523e38/bro//$one_file" -o "$local_path/ja3/$one_file"
done
```

**NOTE:** If the user installed bro from source, `local_path` should be set to `/usr/local/bro/share/bro/site`