### PR TITLE
Prevent Installation Errors When Default Ubuntu Bro Package Is Installed

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -470,6 +470,7 @@ __gather_bro() {
 		printf "$_IMPORTANT For the best results, please stop this script, uninstall Bro, and re-run the installer.\n"
 		printf "\n"
 		printf "$_IMPORTANT Pausing for 20 seconds before continuing. \n"
+		_INSTALL_BRO=false
 		sleep 20
 	fi
 

--- a/install.sh
+++ b/install.sh
@@ -469,9 +469,8 @@ __gather_bro() {
 		printf "$_IMPORTANT RITA has not been tested with this version of Bro and may not function correctly.\n"
 		printf "$_IMPORTANT For the best results, please stop this script, uninstall Bro, and re-run the installer.\n"
 		printf "\n"
-		printf "$_IMPORTANT Press enter to continue installing RITA alongside the existing Bro installation.\n"
-		read -e
-		_INSTALL_BRO=false
+		printf "$_IMPORTANT Pausing for 20 seconds before continuing. \n"
+		sleep 20
 	fi
 
 	_BRO_PATH_SCRIPT="/etc/profile.d/bro-path.sh"

--- a/install.sh
+++ b/install.sh
@@ -99,7 +99,7 @@ __entry() {
 	if [ "$_INSTALL_RITA" = "true" ] && __installation_exist && [ "$_REINSTALL_RITA" != "true" ]; then
 		printf "$_IMPORTANT RITA is already installed.\n"
 		printf "$_QUESTION Would you like to re-install? [y/N] "
-		read
+		read -e
 		if [[ ! $REPLY =~ ^[Yy]$ ]]; then
 			exit 0
 		fi
@@ -462,6 +462,16 @@ __gather_bro() {
 	_BRO_INSTALLED=false
 	if [ $_BRO_PKG_INSTALLED = "true" -o $_BRO_ONION_INSTALLED = "true" -o $_BRO_SOURCE_INSTALLED = "true" ]; then
 		_BRO_INSTALLED=true
+	fi
+
+	if [ "$_INSTALL_BRO" = "true" -a "$_BRO_INSTALLED" = "true" -a ! -d "$_BRO_PATH" ]; then
+		printf "$_IMPORTANT An unsupported version of Bro is installed on this system.\n"
+		printf "$_IMPORTANT RITA has not been tested with this version of Bro and may not function correctly.\n"
+		printf "$_IMPORTANT For the best results, please stop this script, uninstall Bro, and re-run the installer.\n"
+		printf "\n"
+		printf "$_IMPORTANT Press enter to continue installing RITA alongside the existing Bro installation.\n"
+		read -e
+		_INSTALL_BRO=false
 	fi
 
 	_BRO_PATH_SCRIPT="/etc/profile.d/bro-path.sh"


### PR DESCRIPTION
Adds a catch and warning for when the user has a Bro package installed that does not contain its files in `/opt/bro`. If the user has a Bro package installed that the install script does not recognize, the script disables the Bro installation routine and displays a message to the user.

This warning will show itself if the user has installed the default Bro package on Ubuntu 16 or 18.

Currently, if a user installs RITA alongside the default Bro packages from the Ubuntu repositories, they will receive a message like the following:
```
[-] Bro IDS is already installed
grep: /opt/bro/bin/../share/bro/site//local.bro: No such file or directory
If you need to check or change your network interfaces, please do so now
by switching to a different terminal and making any changes.  Please note
that any interfaces you would like to use for packet capture must be up
and configured before you continue.  When the interfaces are ready,
please return to this terminal.

Would you like to continue running the Bro configuration script?
You might answer no if you know you have already created a working
node.cfg and do not wish to replace it.  Otherwise we recommend
continuing with this script.
(y/n)?y
Missing bro configuration dir /opt/bro/etc/ or /usr/local/bro/etc , exiting.
[!] Automatic Bro configuration failed.
[!] Please edit /opt/bro/etc/node.cfg and run
[!] 'sudo broctl deploy' to start Bro.
[!] Pausing for 20 seconds before continuing.
```

Result of running `./install.sh --disable-rita --disable-mongo` on an Ubuntu 16 machine with the default Bro package installed after applying this patch:
```
 _ \ _ _| __ __|  \
   /   |     |   _ \
_|_\ ___|   _| _/  _\  v3.1.1

Brought to you by Active CounterMeasures

[-] In order to run the installer, several basic packages must be installed. 
	[-] Updating packages... SUCCESS
	[-] Ensuring curl is installed... SUCCESS
	[-] Ensuring coreutils is installed... SUCCESS
	[-] Ensuring lsb-release is installed... SUCCESS
	[-] Ensuring yum-utils is installed... SUCCESS
[!] An unsupported version of Bro is installed on this system.
[!] RITA has not been tested with this version of Bro and may not function correctly.
[!] For the best results, please stop this script, uninstall Bro, and re-run the installer.

[!] Pausing for 20 seconds before continuing. 
[-] This installer will: 
[!] To finish the installation, reload the system profile with 
[!] 'source /etc/profile'.

 _ \ _ _| __ __|  \
   /   |     |   _ \
_|_\ ___|   _| _/  _\  v3.1.1

Brought to you by Active CounterMeasures

Thank you for installing RITA! Happy hunting! 
```