### PR TITLE
Change RITA build instructions from source

### DIFF
--- a/Contributing.md
+++ b/Contributing.md
@@ -61,7 +61,7 @@ Automated tests are run against each commit on Travis CI. Build results may be v
 ### Gittiquette Summary
 * In order to contribute to RITA, you must fork it
   * Do not `go get` or `git clone` your forked repo
-  * Instead, `git remote add` it to your existing RITA repository
+  * Instead, `git remote set-url origin https://github.com/YOURGITHUBACCOUNT/rita` it to your existing forked RITA repository
 * Split a branch off of master `git checkout -b [a-new-branch]`
 * Push your commits to your remote if you wish to develop in the public
 * When your work is finished, pull down the latest master branch, and rebase

--- a/docs/Manual Installation.md
+++ b/docs/Manual Installation.md
@@ -46,7 +46,7 @@ In order to compile RITA manually you will need to install both [Golang](https:/
 
 At this point you can build RITA from source code.
 
-1. ```go get github.com/activecm/rita``` or ```git clone git@github.com:activecm/rita.git $GOPATH/src/github.com/activecm/rita```
+1. ```go get github.com/activecm/rita``` or ```git clone https://github.com/activecm/rita.git $GOPATH/src/github.com/activecm/rita```
 1. ```cd $GOPATH/src/github.com/activecm/rita```
 1. ```make``` (Note that you will need to have `make` installed. You can use your system's package manager to install it.)
 

--- a/install.sh
+++ b/install.sh
@@ -99,7 +99,7 @@ __entry() {
 	if [ "$_INSTALL_RITA" = "true" ] && __installation_exist && [ "$_REINSTALL_RITA" != "true" ]; then
 		printf "$_IMPORTANT RITA is already installed.\n"
 		printf "$_QUESTION Would you like to re-install? [y/N] "
-		read -e
+		read
 		if [[ ! $REPLY =~ ^[Yy]$ ]]; then
 			exit 0
 		fi
@@ -471,16 +471,6 @@ __gather_bro() {
 	_BRO_INSTALLED=false
 	if [ $_BRO_PKG_INSTALLED = "true" -o $_BRO_ONION_INSTALLED = "true" -o $_BRO_SOURCE_INSTALLED = "true" ]; then
 		_BRO_INSTALLED=true
-	fi
-
-	if [ "$_INSTALL_BRO" = "true" -a "$_BRO_INSTALLED" = "true" -a ! -d "$_BRO_PATH" ]; then
-		printf "$_IMPORTANT An unsupported version of Bro is installed on this system.\n"
-		printf "$_IMPORTANT RITA has not been tested with this version of Bro and may not function correctly.\n"
-		printf "$_IMPORTANT For the best results, please stop this script, uninstall Bro, and re-run the installer.\n"
-		printf "\n"
-		printf "$_IMPORTANT Pausing for 20 seconds before continuing. \n"
-		_INSTALL_BRO=false
-		sleep 20
 	fi
 
 	_BRO_PATH_SCRIPT="/etc/profile.d/bro-path.sh"


### PR DESCRIPTION
Change RITA build instructions from source to use https for git clone instead of SSH to avoid permission denied error.

```
src $ git clone git@github.com:activecm/rita.git $GOPATH/src/github.com/activecm/rita
Cloning into '/Users/jwright/go/src/github.com/activecm/rita'...
Warning: Permanently added the RSA host key for IP address '140.82.114.3' to the list of known hosts.
git@github.com: Permission denied (publickey).
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
src $ git clone https://github.com/activecm/rita.git $GOPATH/src/github.com/activecm/rita
Cloning into '/Users/jwright/go/src/github.com/activecm/rita'...
remote: Enumerating objects: 23, done.
remote: Counting objects: 100% (23/23), done.
remote: Compressing objects: 100% (23/23), done.
remote: Total 5675 (delta 7), reused 1 (delta 0), pack-reused 5652
Receiving objects: 100% (5675/5675), 6.89 MiB | 8.31 MiB/s, done.
Resolving deltas: 100% (3613/3613), done.
```