### PR TITLE
Gittiquete summary fix

### DIFF
--- a/Contributing.md
+++ b/Contributing.md
@@ -61,7 +61,7 @@ Automated tests are run against each commit on Travis CI. Build results may be v
 ### Gittiquette Summary
 * In order to contribute to RITA, you must fork it
   * Do not `go get` or `git clone` your forked repo
-  * Instead, `git remote add` it to your existing RITA repository
+  * Instead, `git remote set-url origin https://github.com/YOURGITHUBACCOUNT/rita` it to your existing forked RITA repository
 * Split a branch off of master `git checkout -b [a-new-branch]`
 * Push your commits to your remote if you wish to develop in the public
 * When your work is finished, pull down the latest master branch, and rebase

--- a/docs/Manual Installation.md
+++ b/docs/Manual Installation.md
@@ -46,7 +46,7 @@ In order to compile RITA manually you will need to install both [Golang](https:/
 
 At this point you can build RITA from source code.
 
-1. ```go get github.com/activecm/rita``` or ```git clone git@github.com:activecm/rita.git $GOPATH/src/github.com/activecm/rita```
+1. ```go get github.com/activecm/rita``` or ```git clone https://github.com/activecm/rita.git $GOPATH/src/github.com/activecm/rita```
 1. ```cd $GOPATH/src/github.com/activecm/rita```
 1. ```make``` (Note that you will need to have `make` installed. You can use your system's package manager to install it.)
 


### PR DESCRIPTION
Correct _Gittiquette Summary_ note in Contributing.md; repoint repo to fork using `git remote set-url`, not `git remote add`.

```
docs (master) $ git remote set-url origin https://github.com/joswr1ght/rita
docs (master) $ git push
Enumerating objects: 7, done.
Counting objects: 100% (7/7), done.
Delta compression using up to 4 threads
Compressing objects: 100% (4/4), done.
Writing objects: 100% (4/4), 433 bytes | 433.00 KiB/s, done.
Total 4 (delta 3), reused 0 (delta 0)
remote: Resolving deltas: 100% (3/3), completed with 3 local objects.
To https://github.com/joswr1ght/rita
   ece0923..44d2ee0  master -> master
```