### PR TITLE
Terminal width human reporting (for exploded dns)

### DIFF
--- a/commands/show-explodedDns.go
+++ b/commands/show-explodedDns.go
@@ -62,7 +62,8 @@ func init() {
 	bootstrapCommands(command)
 }
 
-func SplitSubN(s string, n int) []string {
+// splitSubN splits s every n characters
+func splitSubN(s string, n int) []string {
 	sub := ""
 	subs := []string{}
 
@@ -94,7 +95,7 @@ func showDNSResults(dnsResults []explodeddns.AnalysisView) error {
 }
 
 func showDNSResultsHuman(dnsResults []explodeddns.AnalysisView) error {
-    const DOMAINRECLEN = 80
+ 	const DOMAINRECLEN = 80
 	table := tablewriter.NewWriter(os.Stdout)
 	table.SetAutoWrapText(true)
 	table.SetRowSeparator("-")
@@ -104,7 +105,7 @@ func showDNSResultsHuman(dnsResults []explodeddns.AnalysisView) error {
 		domain := result.Domain
 		if (len(domain) > DOMAINRECLEN) {
 			// Reformat the result.Domain value adding a newline every DOMAINRECLEN chars for wrapping
-			subs := SplitSubN(result.Domain, DOMAINRECLEN)
+			subs := splitSubN(result.Domain, DOMAINRECLEN)
 			domain = strings.Join(subs, "\n")
 		}
 		table.Append([]string{


### PR DESCRIPTION
Wrap long domain names in human readable table view for show-exploded-dns.

This PR is a hack, shared to support a feature request. The human readable output of RITA is very difficult to parse on terminals where width is less than the total table size. I've changed the max domain name length per line to an arbitrary 80 characters, wrapping longer values to a new line. This change also requires the addition of a row separator line, to avoid confusion where a wrapped line could appear as a new record.

If there's a better way to represent or implement this, I'm all ears! 
![before](https://user-images.githubusercontent.com/1318817/73490193-fc3a3b80-4379-11ea-87e4-c0258556c582.png)
![after2](https://user-images.githubusercontent.com/1318817/73490194-fc3a3b80-4379-11ea-8073-fd7bf9fb931f.png)
![after1](https://user-images.githubusercontent.com/1318817/73490195-fc3a3b80-4379-11ea-813c-f9871ec05b40.png)


