### PR TITLE
Human readable duration for show-long-connections output

### DIFF
--- a/commands/show-long-connections.go
+++ b/commands/show-long-connections.go
@@ -102,7 +102,7 @@ func showConns(connResults []uconn.LongConnAnalysisView) error {
 			result.Src,
 			result.Dst,
 			strings.Join(result.Tuples, " "),
-			duration(time.Duration(int(result.MaxDuration*float64(time.Second)))),
+			f(result.MaxDuration),
 		})
 	}
 	csvWriter.Flush()
@@ -118,7 +118,6 @@ func showConnsHuman(connResults []uconn.LongConnAnalysisView) error {
 			result.Src,
 			result.Dst,
 			strings.Join(result.Tuples, ",\n"),
-			//duration(time.Duration(int(result.MaxDuration*float64(time.Second)))) + "/" + f(result.MaxDuration),
 			duration(time.Duration(int(result.MaxDuration*float64(time.Second)))),
 		})
 	}

--- a/commands/show-long-connections.go
+++ b/commands/show-long-connections.go
@@ -4,6 +4,8 @@ import (
 	"encoding/csv"
 	"os"
 	"strings"
+	"time"
+	"fmt"
 
 	"github.com/activecm/rita/pkg/uconn"
 	"github.com/activecm/rita/resources"
@@ -65,6 +67,32 @@ func init() {
 	bootstrapCommands(command)
 }
 
+const (
+	day  = time.Minute * 60 * 24
+	year = 365 * day
+)
+
+// https://gist.github.com/harshavardhana/327e0577c4fed9211f65#gistcomment-2557682
+func duration(d time.Duration) string {
+	if d < day {
+		return d.String()
+	}
+
+	var b strings.Builder
+
+	if d >= year {
+		years := d / year
+		fmt.Fprintf(&b, "%dy", years)
+		d -= years * year
+	}
+
+	days := d / day
+	d -= days * day
+	fmt.Fprintf(&b, "%dd%s", days, d)
+
+	return b.String()
+}
+
 func showConns(connResults []uconn.LongConnAnalysisView) error {
 	csvWriter := csv.NewWriter(os.Stdout)
 	csvWriter.Write([]string{"Source IP", "Destination IP",
@@ -74,7 +102,7 @@ func showConns(connResults []uconn.LongConnAnalysisView) error {
 			result.Src,
 			result.Dst,
 			strings.Join(result.Tuples, " "),
-			f(result.MaxDuration),
+			duration(time.Duration(int(result.MaxDuration*float64(time.Second)))),
 		})
 	}
 	csvWriter.Flush()
@@ -90,7 +118,8 @@ func showConnsHuman(connResults []uconn.LongConnAnalysisView) error {
 			result.Src,
 			result.Dst,
 			strings.Join(result.Tuples, ",\n"),
-			f(result.MaxDuration) + "s",
+			//duration(time.Duration(int(result.MaxDuration*float64(time.Second)))) + "/" + f(result.MaxDuration),
+			duration(time.Duration(int(result.MaxDuration*float64(time.Second)))),
 		})
 	}
 	table.Render()


### PR DESCRIPTION
Change the duration value in `show-long-connections` to a human-readable duration.

This change introduces human readable duration to the output of `show-long-connections`. The old display was a number of seconds, which were sometimes represented as an exponential value, which is kind of hard for most users to parse easily. This change modified the duration to display time in a readable format. See attached screenshots.
![old](https://user-images.githubusercontent.com/1318817/73507322-a334cc80-43a6-11ea-9478-d4cd6f313210.png)
![new](https://user-images.githubusercontent.com/1318817/73507329-a4fe9000-43a6-11ea-8570-7f50fab3685b.png)

