### PR TITLE
Fixed spelling in fsimporter

### DIFF
--- a/parser/fsimporter.go
+++ b/parser/fsimporter.go
@@ -739,7 +739,7 @@ func (fs *FSImporter) buildUconns(uconnMap map[string]*uconn.Pair) {
 	} else {
 		fmt.Println("\t[!] No Uconn data to analyze")
 		fmt.Printf("\t\t[!!] No local network traffic found, please check ")
-		fmt.Println("InternalSubnets in your RTIA config (/etc/rita/config.yaml)")
+		fmt.Println("InternalSubnets in your RITA config (/etc/rita/config.yaml)")
 	}
 
 }
@@ -759,7 +759,7 @@ func (fs *FSImporter) buildHosts(hostMap map[string]*host.IP) {
 	} else {
 		fmt.Println("\t[!] No Host data to analyze")
 		fmt.Printf("\t\t[!!] No local network traffic found, please check ")
-		fmt.Println("InternalSubnets in your RTIA config (/etc/rita/config.yaml)")
+		fmt.Println("InternalSubnets in your RITA config (/etc/rita/config.yaml)")
 	}
 }
 


### PR DESCRIPTION
Fixed the spelling of RITA in the buildUconns and buildHosts functions in fsimporter.go

Closes #550 