### PR TITLE
Install bro 2.5.5 for ubuntu xenial; Use ACM managed repos

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -197,42 +197,26 @@ __install_installer_deps() {
 __install_bro() {
 
 
-	if [ "$_OS" != "Ubuntu" -o "$_OS_CODENAME" != "xenial" ]; then
+	if  [ "$_OS" == "Ubuntu" ] && [ "$_OS_CODENAME" == "xenial" -o "$_OS_CODENAME" == "trusty" ] ; then
+		# Bro 2.6 will not compile under Debian 8/ Ubuntu Trusty/ Xenial in the OpenSuse Build Service
+		# Install Bro 2.5.5
+		__add_deb_repo "deb http://download.opensuse.org/repositories/home:/logan_bhis:/branches:/network:/bro/xUbuntu_$(lsb_release -rs)/ /" \
+			"Bro" \
+			"https://download.opensuse.org/repositories/home:logan_bhis:branches:network:bro/xUbuntu_$(lsb_release -rs)/Release.key"
+	else
 		case "$_OS" in
 			Ubuntu)
-				__add_deb_repo "deb http://download.opensuse.org/repositories/network:/bro/xUbuntu_$(lsb_release -rs)/ /" \
+				__add_deb_repo "deb http://download.opensuse.org/repositories/home:/logan_bhis:/branches:/network:/bro-2-6/xUbuntu_$(lsb_release -rs)/ /" \
 					"Bro" \
-					"http://download.opensuse.org/repositories/network:bro/xUbuntu_$(lsb_release -rs)/Release.key"
+					"https://download.opensuse.org/repositories/home:logan_bhis:branches:network:bro-2-6/xUbuntu_$(lsb_release -rs)/Release.key"
 				;;
 			CentOS|RedHatEnterprise|RedHatEnterpriseServer)
-				__add_rpm_repo http://download.opensuse.org/repositories/network:bro/CentOS_7/network:bro.repo
+				__add_rpm_repo https://download.opensuse.org/repositories/home:logan_bhis:branches:network:bro-2-6/CentOS_7/home:logan_bhis:branches:network:bro-2-6.repo
 				;;
 		esac
-		__install_packages bro broctl
-	else  # "$_OS" = "Ubuntu" -a "$_OS_CODENAME" = "xenial"
-		# Bro 2.6 will not compile under Ubuntu Xenial in the OpenSuse Build Service
-		# Manually download and install Bro 2.5.5 for Ubuntu Xenial
-		local tmpdir=`mktemp -d -q "$HOME/rita-install.XXXXXXXX" < /dev/null`
-		if [ ! -d "$tmpdir" ]; then
-			tmpdir=.
-		fi
-
-		local bro_xenial_debs=(
-			"https://download.opensuse.org/repositories/home:/logan_bhis:/branches:/network:/bro/xUbuntu_16.04/$(dpkg --print-architecture)/bro-core_2.5.5-0_$(dpkg --print-architecture).deb"
-			"https://download.opensuse.org/repositories/home:/logan_bhis:/branches:/network:/bro/xUbuntu_16.04/$(dpkg --print-architecture)/bro_2.5.5-0_$(dpkg --print-architecture).deb"
-			"https://download.opensuse.org/repositories/home:/logan_bhis:/branches:/network:/bro/xUbuntu_16.04/$(dpkg --print-architecture)/broctl_2.5.5-0_$(dpkg --print-architecture).deb"
-		)
-
-		for url in ${bro_xenial_debs[@]}; do
-			(cd "$tmpdir" && curl -sSLO "$url")
-		done
-
-		__install_packages libpcap0.8 libssl1.0.0 python
-		dpkg -i "$tmpdir/bro-core_2.5.5-0_$(dpkg --print-architecture).deb"
-		dpkg -i "$tmpdir/broctl_2.5.5-0_$(dpkg --print-architecture).deb"
-		dpkg -i "$tmpdir/bro_2.5.5-0_$(dpkg --print-architecture).deb"
 	fi
 
+	__install_packages bro broctl
 
 	if [ -d /opt/bro/logs/ ]; then		#Standard directory for Bro logs when installed by Rita
 		chmod 2755 /opt/bro/logs

--- a/install.sh
+++ b/install.sh
@@ -443,7 +443,7 @@ __gather_pkg_mgr() {
 	_PKG_INSTALL=""
 	if [ -x /usr/bin/apt-get ];	then
 		_PKG_MGR=1
-		_PKG_INSTALL="apt-get -qq install -y"
+		_PKG_INSTALL="DEBIAN_FRONTEND=noninteractive apt-get -qq install -y"
 	elif [ -x /usr/bin/yum ];	then
 		_PKG_MGR=2
 		_PKG_INSTALL="yum -y -q install"


### PR DESCRIPTION
Bro 2.6 will not compile under Ubuntu Xenial in the OpenSuse Build Service. This breaks the bro installation on Xenial. I've copied the build files for Bro 2.6 and edited them to build Bro 2.5.5 for Xenial in OBS. 

~I have the script download the debs and install them manually so this one off repo isn't installed into RITA users' machines. This prevents the need to migrate users' repo configs once RITA migrates to using Zeek.~

This PR changes the installer to use ACM managed repos for both Bro 2.6 and Bro 2.5.5.

I've also removed a couple usages of sudo that were unnecessary since the script requires super user permissions up front. These sudo calls broke the script while I was testing in docker.

