### PR TITLE
Batch Files During Import To Lower RAM Usage

### DIFF
--- a/parser/fsimporter.go
+++ b/parser/fsimporter.go
@@ -204,9 +204,7 @@ func (fs *FSImporter) Run(indexedFiles []*fpt.IndexedFile) {
 		updateFilesIndex(indexedFileBatch, fs.res.MetaDB, fs.res.Log)
 	}
 
-	//////////////////////////////////////////// end upsert maps
-
-	// add min/max timestamps to metaDatabase and mark results as imported and analyzed
+	// mark results as imported and analyzed
 	fmt.Println("\t[-] Updating metadatabase ... ")
 	fs.res.MetaDB.MarkDBAnalyzed(fs.res.DB.GetSelectedDB(), true)
 

--- a/parser/fsimporter.go
+++ b/parser/fsimporter.go
@@ -63,7 +63,7 @@ func NewFSImporter(res *resources.Resources,
 		currentChunk:    res.Config.S.Rolling.CurrentChunk,
 		indexingThreads: indexingThreads,
 		parseThreads:    parseThreads,
-		batchSizeBytes:  2 * (2 << 30), // 2 gigabytes //3840711 <- Splits DNSCAT into 12 batches
+		batchSizeBytes:  2 * (2 << 30), // 2 gigabytes (used to not run out of memory while importing)
 		internal:        getParsedSubnets(res.Config.S.Filtering.InternalSubnets),
 		alwaysIncluded:  getParsedSubnets(res.Config.S.Filtering.AlwaysInclude),
 		neverIncluded:   getParsedSubnets(res.Config.S.Filtering.NeverInclude),


### PR DESCRIPTION
This PR attempts to put a cap on the amount of RAM needed to run RITA. It does so by batching up imports and importing each batch into the same chunk. 

The new code batches the input files by gathers N files of every type such that each 
batch doesn't exceed 2 GB in file size and imports each batch into the same chunk.
It does this by first sorting the input files by path and then grouping them by file type (conn/ http/ ssl/ etc). Next, it greedily takes the next available file from each file type group. If adding the next set of files would make the current batch too large, it splits off the current batch and starts a new one.

This PR relies on zeekctl to create the bro files properly and rotate them at a regular interval for the best experience. If there is not an even number of files of each type, some types of data may not be fed through the upsert process and error messages may be displayed. For example, if there are less conn logs than dns logs, the user will see a warning about missing conn information while processing the last few batches of logs. However, these warnings are cosmetic. Our upsert procedures should not rely on importing the same observation period across log types.

There is an issue in the beaconing reports if you import a dataset in one shot and compare it against the same dataset imported in batches. The beaconing algorithm relies on the min and max timestamps for the dataset. We adjust the min and max timestamps before running beaconing during every import. This ensures that any newly calculated beacons use the correct observation period boundaries. However, we do not re-calculate the beacon scores for beacons derived in previous runs unless the current batch/chunk contains a new, related connection. 

To test the PR using the DNSCAT sample data, switch the batchSizeBytes in the fs importer to the value in the comment. `batchSizeBytes` controls the best-effort maximum size of each batch in bytes. Lowering it will force the small DNSCAT dataset to be imported in batches.

I haven't measured the RAM usage before and after the patch, but I'd like to find time to do so in the future. Perhaps we should make the batch file size limit configurable so users with more RAM can get results faster. Batching the imports does slow down the import process a considerable amount.