### PR TITLE
Remove error printed on every incompatible file

### DIFF
--- a/parser/indexedfile.go
+++ b/parser/indexedfile.go
@@ -150,12 +150,11 @@ func indexFiles(files []string, indexingThreads int, res *resources.Resources) [
 			for j := start; j < length; j += jump {
 				indexedFile, err := newIndexedFile(files[j], res)
 				if err != nil {
+					// log file is likely unsupported or empty
 					res.Log.WithFields(log.Fields{
 						"file":  files[j],
 						"error": err.Error(),
-					}).Debug("An error was encountered while indexing a file")
-					//errored on files will be nil
-					fmt.Printf("\t[!] An error occured while indexing %v. Perhaps this log is empty?", files[j])
+					}).Debug("An error was encountered while indexing a file.")
 					continue
 				}
 				indexedFiles[j] = indexedFile


### PR DESCRIPTION
The change made in https://github.com/activecm/rita/pull/555 introduced a new error message that is printed on every incompatible log file encountered. https://github.com/activecm/rita/pull/555/files#diff-db535b165427291263a2f98e046f30e0R158

However, there is no newline at the end of that message which makes all the errors run together if there are more than one. For example:

```
	[!] An error occured while indexing ignore/empire-ssh/capture_loss.05:00:00-06:00:00.log. Perhaps this log is empty?	[!] An error occured while indexing ignore/empire-ssh/capture_loss.02:00:00-03:00:00.log. Perhaps this log is empty?	[!] An error occured while indexing ignore/empire-ssh/capture_loss.11:00:00-12:00:00.log. Perhaps this log is empty?	[!] An error occured while indexing ignore/empire-ssh/capture_loss.08:00:00-09:00:00.log. Perhaps this log is empty?	[!] An error occured while indexing ignore/empire-ssh/capture_loss.17:00:00-18:00:00.log. Perhaps this log is empty?	[!] An error occured while indexing ignore/empire-ssh/capture_loss.23:00:00-00:00:00.log. Perhaps this log is empty?	[!] An error occured while indexing ignore/empire-ssh/capture_loss.14:00:00-15:00:00.log. Perhaps this log is empty?	[!] An error occured while indexing ignore/empire-ssh/capture_loss.00:00:00-01:00:00.log. Perhaps this log is empty?	[!] An error occured while indexing ignore/empire-ssh/capture_loss.20:00:00-21:00:00.log. Perhaps this log is empty?	[!] An error occured while indexing ignore/empire-ssh/capture_loss.06:00:00-07:00:00.log. Perhaps this log is empty?	[!] An error occured while indexing ignore/empire-ssh/capture_loss.01:00:00-02:00:00.log. Perhaps this log is empty?	[!] An error occured while indexing ignore/empire-ssh/communication.05:00:00-06:00:00.log. Perhaps this log is empty?	[!] An error occured while indexing ignore/empire-ssh/capture_loss.07:00:00-08:00:00.log. Perhaps this log is empty?	[!] An error occured while indexing ignore/empire-ssh/capture_loss.12:00:00-13:00:00.log. Perhaps this log is empty?	[!] An error occured while indexing ignore/empire-ssh/communication.02:00:00-03:00:00.log. Perhaps this log is empty?	[!] An error occured while indexing ignore/empire-ssh/capture_loss.13:00:00-14:00:00.log. Perhaps this log is empty?	[!] An error occured while indexing ignore/empire-ssh/capture_loss.03:00:00-04:00:00.log. Perhaps this log is empty?	[!] An error occured while indexing ignore/empire-ssh/capture_loss.04:00:00-05:00:00.log. Perhaps this log is empty?	[!] An error occured while indexing ignore/empire-ssh/communication.11:00:00-12:00:00.log. Perhaps this log is empty?	[!] An error occured while indexing ignore/empire-ssh/communication.08:00:00-09:00:00.log. Perhaps this log is empty?	[!] An error occured while indexing ignore/empire-ssh/capture_loss.18:00:00-19:00:00.log. Perhaps this log is empty?	[!] An error occured while indexing ignore/empire-ssh/capture_loss.10:00:00-11:00:00.log. Perhaps this log is empty?	[!] An error occured while indexing ig
```

Adding the newline fixes the formatting but the output is still too verbose.
```
	[!] An error occured while indexing ignore/empire-ssh/capture_loss.05:00:00-06:00:00.log. Perhaps this log is empty?
	[!] An error occured while indexing ignore/empire-ssh/capture_loss.02:00:00-03:00:00.log. Perhaps this log is empty?
	[!] An error occured while indexing ignore/empire-ssh/capture_loss.11:00:00-12:00:00.log. Perhaps this log is empty?
	[!] An error occured while indexing ignore/empire-ssh/capture_loss.17:00:00-18:00:00.log. Perhaps this log is empty?
	[!] An error occured while indexing ignore/empire-ssh/capture_loss.23:00:00-00:00:00.log. Perhaps this log is empty?
	[!] An error occured while indexing ignore/empire-ssh/capture_loss.08:00:00-09:00:00.log. Perhaps this log is empty?
	[!] An error occured while indexing ignore/empire-ssh/capture_loss.03:00:00-04:00:00.log. Perhaps this log is empty?
	[!] An error occured while indexing ignore/empire-ssh/capture_loss.00:00:00-01:00:00.log. Perhaps this log is empty?
	[!] An error occured while indexing ignore/empire-ssh/capture_loss.09:00:00-10:00:00.log. Perhaps this log is empty?
	[!] An error occured while indexing ignore/empire-ssh/communication.05:00:00-06:00:00.log. Perhaps this log is empty?
	[!] An error occured while indexing ignore/empire-ssh/capture_loss.14:00:00-15:00:00.log. Perhaps this log is empty?
	[!] An error occured while indexing ignore/empire-ssh/capture_loss.15:00:00-16:00:00.log. Perhaps this log is empty?
	[!] An error occured while indexing ignore/empire-ssh/capture_loss.01:00:00-02:00:00.log. Perhaps this log is empty?
	[!] An error occured while indexing ignore/empire-ssh/capture_loss.21:00:00-22:00:00.log. Perhaps this log is empty?
	[!] An error occured while indexing ignore/empire-ssh/capture_loss.07:00:00-08:00:00.log. Perhaps this log is empty?
	[!] An error occured while indexing ignore/empire-ssh/communication.11:00:00-12:00:00.log. Perhaps this log is empty?
	[!] An error occured while indexing ignore/empire-ssh/capture_loss.06:00:00-07:00:00.log. Perhaps this log is empty?
	[!] An error occured while indexing ignore/empire-ssh/capture_loss.20:00:00-21:00:00.log. Perhaps this log is empty?
	[!] An error occured while indexing ignore/empire-ssh/communication.03:00:00-04:00:00.log. Perhaps this log is empty?
	[!] An error occured while indexing ignore/empire-ssh/capture_loss.04:00:00-05:00:00.log. Perhaps this log is empty?
	[!] An error occured while indexing ignore/empire-ssh/capture_loss.13:00:00-14:00:00.log. Perhaps this log is empty?
	[!] An error occured while indexing ignore/empire-ssh/communication.17:00:00-18:00:00.log. Perhaps this log is empty?
	[!] An error occured while indexing ignore/empire-ssh/capture_loss.12:00:00-13:00:00.log. Perhaps this log is empty?
	[!] An error occured while indexing ignore/empire-ssh/capture_loss.10:00:00-11:00:00.log. Perhaps this log is empty?
	[!] An error occured while indexing ignore/empire-ssh/capture_loss.19:00:00-20:00:00.log. Perhaps this log is empty?
	[!] An error occured while indexing ignore/empire-ssh/communication.09:00:00-10:00:00.log. Perhaps this log is empty?
	[!] An error occured while indexing ignore/empire-ssh/communication.02:00:00-03:00:00.log. Perhaps this log is empty?
	[!] An error occured while indexing ignore/empire-ssh/capture_loss.16:00:00-17:00:00.log. Perhaps this log is empty?
...
```

This pull request removes the printed out message because:
1) The other message added in #555 `No compatible logs found or all log files provided were empty.` is enough to close the original issue and to let the user know what could have gone wrong.
2) The log file still gets all these messages so if the user needs more info they can go to there instead.
