### PR TITLE
Specify Output Delimiter

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -117,8 +117,11 @@ RITA cycles data into and out of rolling databases in "chunks". You can think of
       * `show-long-connections`: Print long connections and relevant information
       * `show-strobes`: Print connections which occurred with excessive frequency
       * `show-useragents`: Print user agent information
-  * By default RITA displays data in CSV format
+  * By default, RITA displays data in CSV format
+      * `-d [DELIM]` delimits the data by `[DELIM]` instead of a comma
+          * Strings can be provided instead of single characters if desired, e.g. `rita show-beacons -d "---" dataset_name`
       * `-H` displays the data in a human readable format
+          * This takes precedence over the `-d` option
       * Piping the human readable results through `less -S` prevents word wrapping
           * Ex: `rita show-beacons dataset_name -H | less -S`
   * Create a html report with `html-report`

--- a/commands/commands.go
+++ b/commands/commands.go
@@ -111,6 +111,14 @@ var (
 		Name:  "connected, C",
 		Usage: "Show hosts which were connected to this blacklisted entry",
 	}
+
+	// Allows user to specify the delimiter for non-human-readable output; this
+	// is useful if user-agents (or somehow some other field) contains commas
+	delimFlag = cli.StringFlag{
+		Name:  "delimiter, d",
+		Usage: "Use a specific `DELIM` string for non-human-readable output",
+		Value: ",", //default to comma-separated
+	}
 )
 
 // bootstrapCommands simply adds a given command to the allCommands array

--- a/commands/show-bl-hostname.go
+++ b/commands/show-bl-hostname.go
@@ -1,7 +1,7 @@
 package commands
 
 import (
-	"encoding/csv"
+	"fmt"
 	"os"
 	"sort"
 	"strconv"
@@ -24,6 +24,7 @@ func init() {
 			configFlag,
 			limitFlag,
 			noLimitFlag,
+			delimFlag,
 		},
 		Usage:  "Print blacklisted hostnames which received connections",
 		Action: printBLHostnames,
@@ -59,7 +60,7 @@ func printBLHostnames(c *cli.Context) error {
 			return cli.NewExitError(err.Error(), -1)
 		}
 	} else {
-		err = showBLHostnames(data)
+		err = showBLHostnames(data, c.String("delimiter"))
 		if err != nil {
 			return cli.NewExitError(err.Error(), -1)
 		}
@@ -68,11 +69,11 @@ func printBLHostnames(c *cli.Context) error {
 	return nil
 }
 
-func showBLHostnames(hostnames []hostname.AnalysisView) error {
-	csvWriter := csv.NewWriter(os.Stdout)
+func showBLHostnames(hostnames []hostname.AnalysisView, delim string) error {
 	headers := []string{"Host", "Connections", "Unique Connections", "Total Bytes", "Sources"}
 
-	csvWriter.Write(headers)
+	// Print the headers and analytic values, separated by a delimiter
+	fmt.Println(strings.Join(headers, delim))
 	for _, entry := range hostnames {
 
 		serialized := []string{
@@ -85,9 +86,13 @@ func showBLHostnames(hostnames []hostname.AnalysisView) error {
 		sort.Strings(entry.ConnectedHosts)
 		serialized = append(serialized, strings.Join(entry.ConnectedHosts, " "))
 
-		csvWriter.Write(serialized)
+		fmt.Println(
+			strings.Join(
+				serialized,
+				delim,
+			),
+		)
 	}
-	csvWriter.Flush()
 
 	return nil
 }

--- a/commands/show-strobes.go
+++ b/commands/show-strobes.go
@@ -1,8 +1,9 @@
 package commands
 
 import (
-	"encoding/csv"
+	"fmt"
 	"os"
+	"strings"
 
 	"github.com/activecm/rita/pkg/beacon"
 	"github.com/activecm/rita/resources"
@@ -26,6 +27,7 @@ func init() {
 			configFlag,
 			limitFlag,
 			noLimitFlag,
+			delimFlag,
 		},
 		Action: func(c *cli.Context) error {
 			db := c.Args().Get(0)
@@ -60,7 +62,7 @@ func init() {
 				}
 				return nil
 			}
-			err = showStrobes(data)
+			err = showStrobes(data, c.String("delimiter"))
 			if err != nil {
 				return cli.NewExitError(err.Error(), -1)
 			}
@@ -70,13 +72,19 @@ func init() {
 	bootstrapCommands(command)
 }
 
-func showStrobes(strobes []beacon.StrobeAnalysisView) error {
-	csvWriter := csv.NewWriter(os.Stdout)
-	csvWriter.Write([]string{"Source", "Destination", "Connection Count"})
+func showStrobes(strobes []beacon.StrobeAnalysisView, delim string) error {
+	headers := []string{"Source", "Destination", "Connection Count"}
+
+	// Print the headers and analytic values, separated by a delimiter
+	fmt.Println(strings.Join(headers, delim))
 	for _, strobe := range strobes {
-		csvWriter.Write([]string{strobe.Src, strobe.Dst, i(strobe.ConnectionCount)})
+		fmt.Println(
+			strings.Join(
+				[]string{strobe.Src, strobe.Dst, i(strobe.ConnectionCount)},
+				delim,
+			),
+		)
 	}
-	csvWriter.Flush()
 	return nil
 }
 

--- a/commands/show-user-agents.go
+++ b/commands/show-user-agents.go
@@ -1,8 +1,9 @@
 package commands
 
 import (
-	"encoding/csv"
+	"fmt"
 	"os"
+	"strings"
 
 	"github.com/activecm/rita/pkg/useragent"
 	"github.com/activecm/rita/resources"
@@ -26,6 +27,7 @@ func init() {
 			configFlag,
 			limitFlag,
 			noLimitFlag,
+			delimFlag,
 		},
 		Action: func(c *cli.Context) error {
 			db := c.Args().Get(0)
@@ -60,7 +62,7 @@ func init() {
 				}
 				return nil
 			}
-			err = showAgents(data)
+			err = showAgents(data, c.String("delimiter"))
 			if err != nil {
 				return cli.NewExitError(err.Error(), -1)
 			}
@@ -70,13 +72,19 @@ func init() {
 	bootstrapCommands(command)
 }
 
-func showAgents(agents []useragent.AnalysisView) error {
-	csvWriter := csv.NewWriter(os.Stdout)
-	csvWriter.Write([]string{"User Agent", "Times Used"})
+func showAgents(agents []useragent.AnalysisView, delim string) error {
+	headers := []string{"User Agent", "Times Used"}
+
+	// Print the headers and analytic values, separated by a delimiter
+	fmt.Println(strings.Join(headers, delim))
 	for _, agent := range agents {
-		csvWriter.Write([]string{agent.UserAgent, i(agent.TimesUsed)})
+		fmt.Println(
+			strings.Join(
+				[]string{agent.UserAgent, i(agent.TimesUsed)},
+				delim,
+			),
+		)
 	}
-	csvWriter.Flush()
 	return nil
 }
 


### PR DESCRIPTION
Each of the `show` commands now supports a `-d` option that allows the user to specify a delimiter for the command's output. A couple of examples:
- `rita show-beacons -d ~ dataset_name` - Delimits the output by `~` instead of by `,`.
- `rita show-beacons -d "@@@" dataset_name` - Delimits the output by `@@@` instead of by `,`.

Under the hood, each `show` command's file now uses `fmt` to output instead of `encoding/csv`, and each output function now takes an additional `string` argument representing the delimiter. _This is still a comma by default._

The main `Readme.md` has been slightly updated to reflect this new functionality.

Closes #572 