### PR TITLE
Remove connection filter for dns entries

### DIFF
--- a/parser/fsimporter.go
+++ b/parser/fsimporter.go
@@ -570,30 +570,26 @@ func (fs *FSImporter) parseFiles(indexedFiles []*fpt.IndexedFile, parsingThreads
 
 							// increment txt query count for host in uconn
 							if queryTypeName == "TXT" {
-								// get destination for dns record
-								dst := parseDNS.Destination
-								dstIP := net.ParseIP(dst)
+								// We don't filter out the src ips like we do with the conn
+								// section since a c2 channel running over dns could have an
+								// internal ip to internal ip connection and not having that ip
+								// in the host table is limiting
 
-								// Run conn pair through filter to filter out certain connections
-								ignore := fs.filterConnPair(srcIP, dstIP)
-								if !ignore {
-
-									// Check if host map value is set, because this record could
-									// come before a relevant conns record
-									if _, ok := hostMap[srcKey]; !ok {
-										// create new uconn record with src and dst
-										// Set IsLocalSrc and IsLocalDst fields based on InternalSubnets setting
-										// we only need to do this once if the uconn record does not exist
-										hostMap[srcKey] = &host.Input{
-											Host:    srcUniqIP,
-											IsLocal: util.ContainsIP(fs.GetInternalSubnets(), srcIP),
-											IP4:     util.IsIPv4(src),
-											IP4Bin:  util.IPv4ToBinary(srcIP),
-										}
+								// Check if host map value is set, because this record could
+								// come before a relevant conns record
+								if _, ok := hostMap[srcKey]; !ok {
+									// create new uconn record with src and dst
+									// Set IsLocalSrc and IsLocalDst fields based on InternalSubnets setting
+									// we only need to do this once if the uconn record does not exist
+									hostMap[srcKey] = &host.Input{
+										Host:    srcUniqIP,
+										IsLocal: util.ContainsIP(fs.GetInternalSubnets(), srcIP),
+										IP4:     util.IsIPv4(src),
+										IP4Bin:  util.IPv4ToBinary(srcIP),
 									}
-									// increment txt query count
-									hostMap[srcKey].TXTQueryCount++
 								}
+								// increment txt query count
+								hostMap[srcKey].TXTQueryCount++
 
 							}
 


### PR DESCRIPTION
Closes #607
Removed the connection filter for only the dns entries so that those host ip's can get added to the hosts table.

[dns-test (1).tar.gz](https://github.com/activecm/rita/files/5974284/dns-test.1.tar.gz)

For this dataset that previously would not import the host creating the dns queries, rita now imports said host.
![image](https://user-images.githubusercontent.com/24681559/107822853-c7aedd00-6d4c-11eb-9d54-32a30595645d.png)
