### PR TITLE
Change TXT query count to max DNS query count

### DIFF
--- a/parser/fsimporter.go
+++ b/parser/fsimporter.go
@@ -592,31 +592,17 @@ func (fs *FSImporter) parseFiles(indexedFiles []*fpt.IndexedFile, parsingThreads
 									}
 								}
 
-								// if there are no entries in the maxdnsquerycount map for this
+								// if there are no entries in the dnsquerycount map for this
 								// srcKey, initialize map
-								if hostMap[srcKey].MaxDNSQueryCount == nil {
-									hostMap[srcKey].MaxDNSQueryCount = make(map[string]int64)
+								if hostMap[srcKey].DNSQueryCount == nil {
+									hostMap[srcKey].DNSQueryCount = make(map[string]int64)
 								}
 
-								// split the domain string on periods
-								split := strings.Split(domain, ".")
-
-								// we will not count the very last item, because it will be either all or
-								// a part of the tlds. This means that something like ".co.uk" will still
-								// not be fully excluded, but it will greatly reduce the complexity for the
-								// most common tlds
-								max := len(split) - 1
-
-								for i := 1; i <= max; i++ {
-									// parse domain which will be the part we are on until the end of the string
-									entry := strings.Join(split[max-i:], ".")
-									// increment the dns query count for this exploded domain
-									hostMap[srcKey].MaxDNSQueryCount[entry]++
-								}
+								// increment the dns query count for this domain
+								hostMap[srcKey].DNSQueryCount[domain]++
 							}
 
-
-						mutex.Unlock()
+							mutex.Unlock()
 
 							/// *************************************************************///
 							///                             HTTP                             ///

--- a/pkg/host/analyzer.go
+++ b/pkg/host/analyzer.go
@@ -181,26 +181,17 @@ func (a *analyzer) start() {
 
 //shouldInsertNewRecord returns true if a host entry with the current CID does not exist in the database
 func (a *analyzer) shouldInsertNewHostRecord(ssn *mgo.Session, host data.UniqueIP) bool {
-	newRecordFlag := false
-	type hostRes struct {
+	var hostCIDs []struct {
 		CID int `bson:"cid"`
 	}
 
-	var res2 []hostRes
+	_ = ssn.DB(a.db.GetSelectedDB()).C(a.conf.T.Structure.HostTable).Find(host.BSONKey()).All(&hostCIDs)
 
-	_ = ssn.DB(a.db.GetSelectedDB()).C(a.conf.T.Structure.HostTable).Find(host.BSONKey()).All(&res2)
-
-	if !(len(res2) > 0) {
-		newRecordFlag = true
-		// fmt.Println("host no results", res2, datum.Host)
-	} else {
-
-		if res2[0].CID != a.chunk {
-			// fmt.Println("host existing", a.chunk, res2, datum.Host)
-			newRecordFlag = true
-		}
+	if len(hostCIDs) <= 0 || hostCIDs[0].CID != a.chunk {
+		// fmt.Println("host no results", len(hostCIDs), host.IP)
+		return true
 	}
-	return newRecordFlag
+	return false
 }
 
 //standardQuery ...

--- a/pkg/host/analyzer.go
+++ b/pkg/host/analyzer.go
@@ -114,7 +114,7 @@ func (a *analyzer) start() {
 }
 
 //standardQuery ...
-func standardQuery(chunk int, chunkStr string, ip data.UniqueIP, local bool, ip4 bool, ip4bin int64, maxdur float64, maxDnsQCount int64, untrustedACC int64, countSrc int, countDst int, blacklisted bool, newFlag bool) update {
+func standardQuery(chunk int, chunkStr string, ip data.UniqueIP, local bool, ip4 bool, ip4bin int64, maxdur float64, maxDNSQCount int64, untrustedACC int64, countSrc int, countDst int, blacklisted bool, newFlag bool) update {
 	var output update
 
 	// create query
@@ -134,7 +134,7 @@ func standardQuery(chunk int, chunkStr string, ip data.UniqueIP, local bool, ip4
 			"dat": bson.M{
 				"count_src":       countSrc,
 				"count_dst":       countDst,
-				"max_dns_query_count": maxDnsQCount,
+				"max_dns_query_count": maxDNSQCount,
 				"upps_count":      untrustedACC,
 				"cid":             chunk,
 			}}
@@ -148,7 +148,7 @@ func standardQuery(chunk int, chunkStr string, ip data.UniqueIP, local bool, ip4
 		query["$inc"] = bson.M{
 			"dat.$.count_src":       countSrc,
 			"dat.$.count_dst":       countDst,
-			"dat.$.max_dns_query_count": maxDnsQCount,
+			"dat.$.max_dns_query_count": maxDNSQCount,
 			"dat.$.upps_count":      untrustedACC,
 		}
 

--- a/pkg/host/analyzer.go
+++ b/pkg/host/analyzer.go
@@ -150,7 +150,7 @@ func (a *analyzer) start() {
 					if newRecordFlag {
 						input.selector = datum.Host.BSONKey()
 					} else {
-						// if this is an exisitng host, use the host & cid as the selectors
+						// if this is an existing host, use the host & cid as the selectors
 						input.selector = datum.Host.BSONKey()
 						input.selector["dat.cid"] = a.chunk
 					}

--- a/pkg/host/analyzer.go
+++ b/pkg/host/analyzer.go
@@ -89,7 +89,7 @@ func (a *analyzer) start() {
 					}
 				}
 
-				output = standardQuery(a.chunk, a.chunkStr, datum.Host, datum.IsLocal, datum.IP4, datum.IP4Bin, datum.MaxDuration, datum.TXTQueryCount, datum.UntrustedAppConnCount, datum.CountSrc, datum.CountDst, blacklisted, newRecordFlag)
+				output = standardQuery(a.chunk, a.chunkStr, datum.Host, datum.IsLocal, datum.IP4, datum.IP4Bin, datum.MaxDuration, datum.DNSQueryCount, datum.UntrustedAppConnCount, datum.CountSrc, datum.CountDst, blacklisted, newRecordFlag)
 
 				// set to writer channel
 				a.analyzedCallback(output)
@@ -102,7 +102,7 @@ func (a *analyzer) start() {
 }
 
 //standardQuery ...
-func standardQuery(chunk int, chunkStr string, ip data.UniqueIP, local bool, ip4 bool, ip4bin int64, maxdur float64, txtQCount int64, untrustedACC int64, countSrc int, countDst int, blacklisted bool, newFlag bool) update {
+func standardQuery(chunk int, chunkStr string, ip data.UniqueIP, local bool, ip4 bool, ip4bin int64, maxdur float64, dnsQCount int64, untrustedACC int64, countSrc int, countDst int, blacklisted bool, newFlag bool) update {
 	var output update
 
 	// create query
@@ -122,7 +122,7 @@ func standardQuery(chunk int, chunkStr string, ip data.UniqueIP, local bool, ip4
 			"dat": bson.M{
 				"count_src":       countSrc,
 				"count_dst":       countDst,
-				"txt_query_count": txtQCount,
+				"dns_query_count": dnsQCount,
 				"upps_count":      untrustedACC,
 				"cid":             chunk,
 			}}
@@ -136,7 +136,7 @@ func standardQuery(chunk int, chunkStr string, ip data.UniqueIP, local bool, ip4
 		query["$inc"] = bson.M{
 			"dat.$.count_src":       countSrc,
 			"dat.$.count_dst":       countDst,
-			"dat.$.txt_query_count": txtQCount,
+			"dat.$.dns_query_count": dnsQCount,
 			"dat.$.upps_count":      untrustedACC,
 		}
 

--- a/pkg/host/analyzer.go
+++ b/pkg/host/analyzer.go
@@ -106,8 +106,8 @@ func (a *analyzer) start() {
 				// and retrieve the max dns query count object
 				if len(datum.DNSQueryCount) > 0 {
 					// make a new map to store the exploded dns query->count data
-					var explodedDnsMap map[string]int64
-					explodedDnsMap = make(map[string]int64)
+					var explodedDNSMap map[string]int64
+					explodedDNSMap = make(map[string]int64)
 					for domain, count := range datum.DNSQueryCount {
 						// split name on periods
 						split := strings.Split(domain, ".")
@@ -121,18 +121,18 @@ func (a *analyzer) start() {
 						for i := 1; i <= max; i++ {
 							// parse domain which will be the part we are on until the end of the string
 							entry := strings.Join(split[max-i:], ".")
-							explodedDnsMap[entry] += count
+							explodedDNSMap[entry] += count
 						}
 					}
 
 					// put exploded dns map into mongo format so that we can push the entire
 					// exploded dns map data into the database in one go
-					var explodedDns []explodedDNS
-					for domain, count := range explodedDnsMap {
-						var explodedDnsEntry explodedDNS
-						explodedDnsEntry.Query = domain
-						explodedDnsEntry.Count = count
-						explodedDns = append(explodedDns, explodedDnsEntry)
+					var explodedDNSEntries []explodedDNS
+					for domain, count := range explodedDNSMap {
+						var explodedDNSEntry explodedDNS
+						explodedDNSEntry.Query = domain
+						explodedDNSEntry.Count = count
+						explodedDNSEntries = append(explodedDNSEntries, explodedDNSEntry)
 					}
 
 					// push the host exploded dns results into this host's dat array
@@ -140,7 +140,7 @@ func (a *analyzer) start() {
 					query := bson.M{
 						"$push": bson.M{
 							"dat": bson.M{
-								"exploded_dns": explodedDns,
+								"exploded_dns": explodedDNSEntries,
 								"cid":          a.chunk,
 							},
 						},

--- a/pkg/host/analyzer.go
+++ b/pkg/host/analyzer.go
@@ -28,12 +28,6 @@ type (
 		analysisWg       sync.WaitGroup       // wait for analysis to finish
 		res              *resources.Resources // resources for logger usage
 	}
-
-	// structure for host exploded dns results
-	explodedDNS struct {
-		Query string `bson:"query"`
-		Count int64  `bson:"count"`
-	}
 )
 
 //newAnalyzer creates a new collector for gathering data
@@ -88,7 +82,7 @@ func (a *analyzer) start() {
 				var maxDNSQueryRes explodedDNS
 				// If we have any dns queries for this host, push them to the database
 				// and retrieve the max dns query count object.
-				// If there aren't any explodedDNS results, max_dns_query_count will be set to
+				// If there aren't any explodedDNS results, max_dns will be set to
 				// {"query": "", count: 0}.
 				if len(datum.DNSQueryCount) > 0 {
 					// update the host record with the new exploded dns results
@@ -284,8 +278,8 @@ func standardQuery(chunk int, chunkStr string, ip data.UniqueIP, local bool, ip4
 						"cid":        chunk,
 					},
 					{
-						"max_dns_query_count": maxDNSQueryCount,
-						"cid":                 chunk,
+						"max_dns": maxDNSQueryCount,
+						"cid":     chunk,
 					},
 				},
 			}}
@@ -304,8 +298,8 @@ func standardQuery(chunk int, chunkStr string, ip data.UniqueIP, local bool, ip4
 
 		query["$push"] = bson.M{
 			"dat": bson.M{
-				"max_dns_query_count": maxDNSQueryCount,
-				"cid":                 chunk,
+				"max_dns": maxDNSQueryCount,
+				"cid":     chunk,
 			},
 		}
 

--- a/pkg/host/mongodb.go
+++ b/pkg/host/mongodb.go
@@ -53,6 +53,7 @@ func (r *repo) Upsert(hostMap map[string]*Input) {
 	writerWorker := newWriter(r.res.Config.T.Structure.HostTable, r.res.DB, r.res.Config, r.res.Log)
 
 	analyzerWorker := newAnalyzer(
+		r.res,
 		r.res.Config.S.Rolling.CurrentChunk,
 		r.res.DB,
 		r.res.Config,

--- a/pkg/host/mongodb.go
+++ b/pkg/host/mongodb.go
@@ -53,10 +53,10 @@ func (r *repo) Upsert(hostMap map[string]*Input) {
 	writerWorker := newWriter(r.res.Config.T.Structure.HostTable, r.res.DB, r.res.Config, r.res.Log)
 
 	analyzerWorker := newAnalyzer(
-		r.res,
 		r.res.Config.S.Rolling.CurrentChunk,
-		r.res.DB,
 		r.res.Config,
+		r.res.DB,
+		r.res.Log,
 		writerWorker.collect,
 		writerWorker.close,
 	)

--- a/pkg/host/repository.go
+++ b/pkg/host/repository.go
@@ -34,3 +34,9 @@ type Input struct {
 	IP4                   bool
 	IP4Bin                int64
 }
+
+// explodedDNS is structure for host exploded dns results
+type explodedDNS struct {
+	Query string `bson:"query"`
+	Count int64  `bson:"count"`
+}

--- a/pkg/host/repository.go
+++ b/pkg/host/repository.go
@@ -27,7 +27,7 @@ type Input struct {
 	TotalBytes            int64
 	MaxDuration           float64
 	TotalDuration         float64
-	DNSQueryCount         int64
+	MaxDNSQueryCount      map[string]int64
 	UntrustedAppConnCount int64
 	MaxTS                 int64
 	MinTS                 int64

--- a/pkg/host/repository.go
+++ b/pkg/host/repository.go
@@ -27,7 +27,7 @@ type Input struct {
 	TotalBytes            int64
 	MaxDuration           float64
 	TotalDuration         float64
-	TXTQueryCount         int64
+	DNSQueryCount         int64
 	UntrustedAppConnCount int64
 	MaxTS                 int64
 	MinTS                 int64

--- a/pkg/host/repository.go
+++ b/pkg/host/repository.go
@@ -27,7 +27,7 @@ type Input struct {
 	TotalBytes            int64
 	MaxDuration           float64
 	TotalDuration         float64
-	MaxDNSQueryCount      map[string]int64
+	DNSQueryCount         map[string]int64
 	UntrustedAppConnCount int64
 	MaxTS                 int64
 	MinTS                 int64


### PR DESCRIPTION
- Changed the txt_query_count field to max_dns_query_count
  - max_dns_query_count represents the dns query count for the domain that had the most dns queries made to it by its respective host
- Added a check to only add the host to the host map & increment dns query count if the domain isn't an empty string and doesn't end in in-addr.arpa, since it can create an inaccurate dns query count
- Removed the check for txt queries, making the src ip get added to the host map & incrementing the query count regardless of query type.

For [this dataset](https://github.com/activecm/rita/files/6025257/dns-test.tar.gz), 172.31.26.157 made 
- 2074 queries to *.honestimnotevil.com
- 3 queries to *.aitai.ne.jp

Since *.honestimnotevil.com had the most amount of queries made to it, 2074 makes it into the max_dns_query_count field.


Closes: #609 