### PR TITLE
Count the number of unique subdomains a host looked up for a given (super)domain rather than total number of queries

### DIFF
--- a/pkg/host/analyzer.go
+++ b/pkg/host/analyzer.go
@@ -134,7 +134,7 @@ func buildExplodedDNSArray(dnsQueryCounts map[string]int64) []explodedDNS {
 	// make a new map to store the exploded dns query->count data
 	var explodedDNSMap map[string]int64
 	explodedDNSMap = make(map[string]int64)
-	for domain, count := range dnsQueryCounts {
+	for domain := range dnsQueryCounts {
 		// split name on periods
 		split := strings.Split(domain, ".")
 
@@ -147,7 +147,7 @@ func buildExplodedDNSArray(dnsQueryCounts map[string]int64) []explodedDNS {
 		for i := 1; i <= max; i++ {
 			// parse domain which will be the part we are on until the end of the string
 			entry := strings.Join(split[max-i:], ".")
-			explodedDNSMap[entry] += count
+			explodedDNSMap[entry] += 1
 		}
 	}
 

--- a/pkg/host/analyzer.go
+++ b/pkg/host/analyzer.go
@@ -147,7 +147,7 @@ func buildExplodedDNSArray(dnsQueryCounts map[string]int64) []explodedDNS {
 		for i := 1; i <= max; i++ {
 			// parse domain which will be the part we are on until the end of the string
 			entry := strings.Join(split[max-i:], ".")
-			explodedDNSMap[entry] += 1
+			explodedDNSMap[entry]++
 		}
 	}
 


### PR DESCRIPTION
Fixes #612.

In the `show-exploded-dns` output, we display two values `Times Looked Up` and `Unique Subdomains`. 

Currently the host based exploded dns analysis i.e. `host.max_dns.count` is written to compute the number of times a host looked up the subdomains of a given (super)domain (`host.max_dns.query`). This is akin to the `Times Looked Up` field in the dataset wide exploded dns analysis.

This PR changes `host.max_dns.count` to compute the number of unique subdomains a host looked up for a given (super)domain. This makes the values match the `Unique Subdomains` values reported by `show-exploded-dns`. 