### PR TITLE
set rita version to v4.1.0 in installer

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -4,7 +4,7 @@
 # activecountermeasures.com
 
 # CONSTANTS
-_RITA_VERSION="v4.0.0"
+_RITA_VERSION="v4.1.0"
 _MONGO_VERSION="3.6"
 _NAME=$(basename "${0}")
 _FAILED="\e[91mFAILED\e[0m"


### PR DESCRIPTION
We must edit the target version in the installer before creating a release as per docs/Releases.md.