### PR TITLE
WIP Unexpected protocol: Extend trustedAppReferenceList to include more protocols #577

### DIFF
--- a/parser/fsimporter.go
+++ b/parser/fsimporter.go
@@ -68,11 +68,18 @@ func NewFSImporter(res *resources.Resources,
 		neverIncluded:   util.ParseSubnets(res.Config.S.Filtering.NeverInclude),
 	}
 }
-
+// These protocols are innocent until proven guilty
 var trustedAppReferenceList = [...]trustedAppTiplet{
-	{"tcp", 80, []string{"http"}},
+	{"tcp", 80, []string{"http", "ssl", "http,ssl"}},
 	{"tcp", 443, []string{"ssl"}},
+	{"tcp", 53, []string{"dns"}},
+	{"tcp", 22, []string{"ssh"}},
+	{"udp", 123, []string{"ntp", "-"}},
 	{"udp", 53, []string{"dns"}},
+	{"tcp", 445, []string{"smb"}},
+	{"tcp", 25, []string{"smtp", "ssl", "smtp,ssl"}},
+	{"tcp", 3306, []string{"mysql"}},
+	{"tcp", 143, []string{"imap", "ssl", "imap,ssl"}},
 }
 
 //GetInternalSubnets returns the internal subnets from the config file
@@ -467,7 +474,7 @@ func (fs *FSImporter) parseFiles(indexedFiles []*fpt.IndexedFile, parsingThreads
 												if service != entry.service[i] {
 													hostMap[srcKey].UntrustedAppConnCount++
 													uconnMap[srcDstKey].UPPSFlag = true
-													break;
+													break; // make sure it only doesn't match once
 												}
 											}
 										}

--- a/parser/fsimporter.go
+++ b/parser/fsimporter.go
@@ -47,7 +47,7 @@ type (
 	trustedAppTiplet struct {
 		protocol string
 		port     int
-		service  string
+		service  []string
 	}
 )
 
@@ -70,8 +70,9 @@ func NewFSImporter(res *resources.Resources,
 }
 
 var trustedAppReferenceList = [...]trustedAppTiplet{
-	{"tcp", 80, "http"},
-	{"tcp", 443, "ssl"},
+	{"tcp", 80, []string{"http"}},
+	{"tcp", 443, []string{"ssl"}},
+	{"udp", 53, []string{"dns"}},
 }
 
 //GetInternalSubnets returns the internal subnets from the config file
@@ -462,9 +463,12 @@ func (fs *FSImporter) parseFiles(indexedFiles []*fpt.IndexedFile, parsingThreads
 								if uconnMap[srcDstKey].UPPSFlag == false {
 									for _, entry := range trustedAppReferenceList {
 										if (protocol == entry.protocol) && (dstPort == entry.port) {
-											if service != entry.service {
-												hostMap[srcKey].UntrustedAppConnCount++
-												uconnMap[srcDstKey].UPPSFlag = true
+											for i := range entry.service {
+												if service != entry.service[i] {
+													hostMap[srcKey].UntrustedAppConnCount++
+													uconnMap[srcDstKey].UPPSFlag = true
+													break;
+												}
 											}
 										}
 									}


### PR DESCRIPTION
This expands the list of well known protocol/port/services. Given the potential impact on performance I only included a few that seem to appear most frequently, but it could easily be expanded further. All tests pass, however the intended result has not been verified as I do not know a way to view the data without the AC-Hunter interface. 