### PR TITLE
Domain filtering and fqdn threshold hotfix

### DIFF
--- a/config/static.go
+++ b/config/static.go
@@ -105,9 +105,11 @@ type (
 
 	//FilteringStaticCfg controls address filtering
 	FilteringStaticCfg struct {
-		AlwaysInclude   []string `yaml:"AlwaysInclude" default:"[]"`
-		NeverInclude    []string `yaml:"NeverInclude" default:"[\"0.0.0.0/32\", \"127.0.0.0/8\", \"169.254.0.0/16\", \"224.0.0.0/4\", \"255.255.255.255/32\", \"::1/128\", \"fe80::/10\", \"ff00::/8\"]"`
-		InternalSubnets []string `yaml:"InternalSubnets" default:"[\"10.0.0.0/8\", \"172.16.0.0/12\", \"192.168.0.0/16\"]"`
+		AlwaysInclude       []string `yaml:"AlwaysInclude" default:"[]"`
+		NeverInclude        []string `yaml:"NeverInclude" default:"[\"0.0.0.0/32\", \"127.0.0.0/8\", \"169.254.0.0/16\", \"224.0.0.0/4\", \"255.255.255.255/32\", \"::1/128\", \"fe80::/10\", \"ff00::/8\"]"`
+		InternalSubnets     []string `yaml:"InternalSubnets" default:"[\"10.0.0.0/8\", \"172.16.0.0/12\", \"192.168.0.0/16\"]"`
+		AlwaysIncludeDomain []string `yaml:"AlwaysIncludeDomain" default:"[]"`
+		NeverIncludeDomain  []string `yaml:"NeverIncludeDomain" default:"[]"`
 	}
 
 	//StrobeStaticCfg controls the maximum number of connections between any two given hosts

--- a/etc/rita.yaml
+++ b/etc/rita.yaml
@@ -82,7 +82,24 @@ Filtering:
     - 10.0.0.0/8 # Private-Use Networks  RFC 1918
     - 172.16.0.0/12 # Private-Use Networks  RFC 1918
     - 192.168.0.0/16 # Private-Use Networks  RFC 1918
+  
+  # Example: AlwaysIncludeDomain: ["mydomain.com","*.mydomain.com"]
+  # This functionality overrides the NeverIncludeDomain 
+  # section, making sure that any connection records containing domains
+  # that match this list are kept and not filtered
+  # NOTE: When using wildcards, make sure the added entry is in quotes,
+  #       ie, '*.mydomain.com'. Only subdomain wildcarding 
+  #       (asterisk as the prefix) is supported
+  AlwaysIncludeDomain: []
 
+  # Example: NeverIncludeDomain: ["mydomain.com","*.mydomain.com"]
+  # This functions as a whitelisting setting, and connections involving
+  # ranges entered into this section are filtered out at import time
+  # NOTE: When using wildcards, make sure the added entry is in quotes,
+  #       ie, '*.mydomain.com'. Only subdomain wildcarding 
+  #       (asterisk as the prefix) is supported
+  NeverIncludeDomain: []
+  
 BlackListed:
   Enabled: true
   # These are blacklists built into rita-blacklist. Set these to false

--- a/parser/filter.go
+++ b/parser/filter.go
@@ -1,8 +1,9 @@
 package parser
 
 import (
-	"github.com/activecm/rita/util"
 	"net"
+
+	"github.com/activecm/rita/util"
 )
 
 // filterConnPair returns true if a connection pair is filtered/excluded.
@@ -48,6 +49,32 @@ func (fs *FSImporter) filterConnPair(srcIP net.IP, dstIP net.IP) bool {
 
 	// if both addresses are external, filter applies
 	if (!isSrcInternal) && (!isDstInternal) {
+		return true
+	}
+
+	// default to not filter the connection pair
+	return false
+}
+
+// filterDomain returns true if a domain is filtered/excluded.
+// This is determined by the following rules, in order:
+//   1. Not filtered if domain is on the AlwaysInclude list
+//   2. Filtered if domain is on the NeverInclude list
+//   5. Not filtered in all other cases
+func (fs *FSImporter) filterDomain(domain string) bool {
+	// check if on always included list
+	isDomainIncluded := util.ContainsDomain(fs.alwaysIncludedDomain, domain)
+
+	// check if on never included list
+	isDomainExcluded := util.ContainsDomain(fs.neverIncludedDomain, domain)
+
+	// if either IP is on the AlwaysInclude list, filter does not apply
+	if isDomainIncluded {
+		return false
+	}
+
+	// if either IP is on the NeverInclude list, filter applies
+	if isDomainExcluded {
 		return true
 	}
 

--- a/pkg/beaconfqdn/dissector.go
+++ b/pkg/beaconfqdn/dissector.go
@@ -102,6 +102,7 @@ func (d *dissector) start() {
 					"tbytes": bson.M{"$sum": "$tbytes"},
 					"icerts": bson.M{"$push": "$icerts"},
 				}},
+				{"$match": bson.M{"count": bson.M{"$gt": d.conf.S.BeaconFQDN.DefaultConnectionThresh}}},
 				{"$unwind": bson.M{
 					"path": "$ts",
 					// by default, $unwind does not output a document if the field value is null,

--- a/rita.go
+++ b/rita.go
@@ -9,7 +9,7 @@ import (
 	"github.com/urfave/cli"
 )
 
-// Entry point of ai-hunt
+// Entry point of ac-hunt
 func main() {
 	app := cli.NewApp()
 	app.Name = "rita"

--- a/util/ip.go
+++ b/util/ip.go
@@ -74,6 +74,40 @@ func ContainsIP(subnets []*net.IPNet, ip net.IP) bool {
 	return false
 }
 
+//ContainsDomain checks if a collection of domains contains an IP
+func ContainsDomain(domains []string, host string) bool {
+
+	for _, entry := range domains {
+
+		// check for wildcard
+		if strings.Contains(entry, "*") {
+
+			// trim asterisk from the wildcard domain
+			wildcardDomain := strings.TrimPrefix(entry, "*")
+
+			//This would match a.mydomain.com, b.mydomain.com etc.,
+			if strings.HasSuffix(host, wildcardDomain) {
+				return true
+			}
+
+			// check match of top domain of wildcard
+			// if a user added *.mydomain.com, this will include mydomain.com
+			// in the filtering
+			wildcardDomain = strings.TrimPrefix(wildcardDomain, ".")
+
+			if host == wildcardDomain {
+				return true
+			}
+		} else { // match on exact
+			if host == entry {
+				return true
+			}
+		}
+
+	}
+	return false
+}
+
 // IsIP returns true if string is a valid IP address
 func IsIP(ip string) bool {
 	if net.ParseIP(ip) != nil {


### PR DESCRIPTION
fixed a bug with threshold count for fqdn beacons and added always include and never include functionality for domain filtering