### PR TITLE
Show long cumulative connections

### DIFF
--- a/commands/show-long-cumulative.go
+++ b/commands/show-long-cumulative.go
@@ -1,0 +1,137 @@
+package commands
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/activecm/rita/pkg/uconn"
+	"github.com/activecm/rita/resources"
+	"github.com/olekukonko/tablewriter"
+	"github.com/urfave/cli"
+)
+
+func init() {
+	command := cli.Command{
+
+		Name:      "show-long-cumulative",
+		Usage:     "Print long cumulative connections and relevant information",
+		ArgsUsage: "<database>",
+		Flags: []cli.Flag{
+			humanFlag,
+			configFlag,
+			limitFlag,
+			noLimitFlag,
+			delimFlag,
+			netNamesFlag,
+		},
+		Action: func(c *cli.Context) error {
+			db := c.Args().Get(0)
+			if db == "" {
+				return cli.NewExitError("Specify a database", -1)
+			}
+
+			res := resources.InitResources(c.String("config"))
+			res.DB.SelectDB(db)
+
+			data, err := uconn.LongConnCumulativeResults(res)
+
+			if err != nil {
+				res.Log.Error(err)
+				return cli.NewExitError(err, -1)
+			}
+
+			if !(len(data) > 0) {
+				return cli.NewExitError("No results were found for "+db, -1)
+			}
+
+			if c.Bool("human-readable") {
+				err := showConnsHumanCumulative(data, c.Bool("network-names"))
+				if err != nil {
+					return cli.NewExitError(err.Error(), -1)
+				}
+				return nil
+			}
+			err = showConnsCumulative(data, c.String("delimiter"), c.Bool("network-names"))
+			if err != nil {
+				return cli.NewExitError(err.Error(), -1)
+			}
+			return nil
+		},
+	}
+	bootstrapCommands(command)
+}
+
+func showConnsCumulative(connResults []uconn.LongConnResult, delim string, showNetNames bool) error {
+
+	var headerFields []string
+	if showNetNames {
+		headerFields = []string{"Source Network", "Destination Network", "Source IP", "Destination IP", "Port:Protocol:Service", "Duration"}
+	} else {
+		headerFields = []string{"Source IP", "Destination IP", "Port:Protocol:Service", "Duration"}
+	}
+
+	// Print the headers and analytic values, separated by a delimiter
+	fmt.Println(strings.Join(headerFields, delim))
+	for _, result := range connResults {
+		var row []string
+		if showNetNames {
+			row = []string{
+				result.SrcNetworkName,
+				result.DstNetworkName,
+				result.SrcIP,
+				result.DstIP,
+				strings.Join(result.Tuples, " "),
+				f(result.MaxDuration),
+			}
+		} else {
+			row = []string{
+				result.SrcIP,
+				result.DstIP,
+				strings.Join(result.Tuples, " "),
+				f(result.MaxDuration),
+			}
+		}
+
+		fmt.Println(strings.Join(row, delim))
+	}
+	return nil
+}
+
+func showConnsHumanCumulative(connResults []uconn.LongConnResult, showNetNames bool) error {
+	table := tablewriter.NewWriter(os.Stdout)
+
+	var headerFields []string
+	if showNetNames {
+		headerFields = []string{"Source Network", "Destination Network", "Source IP", "Destination IP", "Port:Protocol:Service", "Duration"}
+	} else {
+		headerFields = []string{"Source IP", "Destination IP", "Port:Protocol:Service", "Duration"}
+	}
+
+	table.SetHeader(headerFields)
+	for _, result := range connResults {
+		var row []string
+		if showNetNames {
+			row = []string{
+				result.SrcNetworkName,
+				result.DstNetworkName,
+				result.SrcIP,
+				result.DstIP,
+				strings.Join(result.Tuples, " "),
+				duration(time.Duration(int(result.MaxDuration * float64(time.Second)))),
+			}
+		} else {
+			row = []string{
+				result.SrcIP,
+				result.DstIP,
+				strings.Join(result.Tuples, " "),
+				duration(time.Duration(int(result.MaxDuration * float64(time.Second)))),
+			}
+		}
+
+		table.Append(row)
+	}
+	table.Render()
+	return nil
+}

--- a/pkg/uconn/results.go
+++ b/pkg/uconn/results.go
@@ -62,3 +62,54 @@ func LongConnResults(res *resources.Resources, thresh int, limit int, noLimit bo
 	return longConnResults, err
 
 }
+
+func LongConnCumulativeResults(res *resources.Resources) ([]LongConnResult, error) {
+	ssn := res.DB.Session.Copy()
+	defer ssn.Close()
+
+	var longConnResults []LongConnResult
+
+	longConnQuery := []bson.M{
+		bson.M{"$match": bson.M{"dat.maxdur": bson.M{"$gt": 0}}},
+		bson.M{"$project": bson.M{
+			"src":              1,
+			"src_network_uuid": 1,
+			"src_network_name": 1,
+			"dst":              1,
+			"dst_network_uuid": 1,
+			"dst_network_name": 1,
+			"maxdur":           "$dat.maxdur",
+			"tuples":           bson.M{"$ifNull": []interface{}{"$dat.tuples", []interface{}{}}},
+		}},
+		bson.M{"$unwind": "$maxdur"},
+		bson.M{"$unwind": "$tuples"},
+		bson.M{"$unwind": "$tuples"}, // not an error, must be done twice
+		bson.M{"$group": bson.M{
+			"_id":              "$_id",
+			"maxdur":           bson.M{"$sum": "$maxdur"},
+			"src":              bson.M{"$first": "$src"},
+			"src_network_uuid": bson.M{"$first": "$src_network_uuid"},
+			"src_network_name": bson.M{"$first": "$src_network_name"},
+			"dst":              bson.M{"$first": "$dst"},
+			"dst_network_uuid": bson.M{"$first": "$dst_network_uuid"},
+			"dst_network_name": bson.M{"$first": "$dst_network_name"},
+			"tuples":           bson.M{"$addToSet": "$tuples"},
+		}},
+		bson.M{"$project": bson.M{
+			"maxdur":           1,
+			"src":              1,
+			"src_network_uuid": 1,
+			"src_network_name": 1,
+			"dst":              1,
+			"dst_network_uuid": 1,
+			"dst_network_name": 1,
+			"tuples":           bson.M{"$slice": []interface{}{"$tuples", 5}},
+		}},
+		bson.M{"$sort": bson.M{"maxdur": -1}},
+	}
+
+	err := ssn.DB(res.DB.GetSelectedDB()).C(res.Config.T.Structure.UniqueConnTable).Pipe(longConnQuery).AllowDiskUse().All(&longConnResults)
+
+	return longConnResults, err
+
+}

--- a/pkg/uconn/results.go
+++ b/pkg/uconn/results.go
@@ -78,7 +78,7 @@ func LongConnCumulativeResults(res *resources.Resources) ([]LongConnResult, erro
 			"dst":              1,
 			"dst_network_uuid": 1,
 			"dst_network_name": 1,
-			"maxdur":           "$dat.maxdur",
+			"maxdur":           "$dat.tdur",
 			"tuples":           bson.M{"$ifNull": []interface{}{"$dat.tuples", []interface{}{}}},
 		}},
 		bson.M{"$unwind": "$maxdur"},
@@ -86,7 +86,7 @@ func LongConnCumulativeResults(res *resources.Resources) ([]LongConnResult, erro
 		bson.M{"$unwind": "$tuples"}, // not an error, must be done twice
 		bson.M{"$group": bson.M{
 			"_id":              "$_id",
-			"maxdur":           bson.M{"$sum": "$maxdur"},
+			"maxdur":           bson.M{"$max": "$maxdur"},
 			"src":              bson.M{"$first": "$src"},
 			"src_network_uuid": bson.M{"$first": "$src_network_uuid"},
 			"src_network_name": bson.M{"$first": "$src_network_name"},
@@ -111,5 +111,4 @@ func LongConnCumulativeResults(res *resources.Resources) ([]LongConnResult, erro
 	err := ssn.DB(res.DB.GetSelectedDB()).C(res.Config.T.Structure.UniqueConnTable).Pipe(longConnQuery).AllowDiskUse().All(&longConnResults)
 
 	return longConnResults, err
-
 }


### PR DESCRIPTION
Adds a new command show-long-cumulative to show long connections based on the tdur rather then the maxdur. The added code is almost identical to show-long-connections. This is useful in detecting beaconing activity where individual TCP sessions may only last a short duration (30 minutes) - but the cumulative duration of the TCP sessions is notable.