### PR TITLE
add flag to prevent auto-launching of browser when generating HTML reports

### DIFF
--- a/commands/commands.go
+++ b/commands/commands.go
@@ -123,6 +123,11 @@ var (
 		Name:  "network-names, nn",
 		Usage: "Show network names associated with IP addresses. Helps when private IPs are reused across multiple physical networks.",
 	}
+
+	noBrowserFlag = cli.BoolFlag{
+		Name:  "no-browser, nb",
+		Usage: "Prevent auto-launching of default browser.",
+	}
 )
 
 // bootstrapCommands simply adds a given command to the allCommands array

--- a/commands/reporting.go
+++ b/commands/reporting.go
@@ -16,6 +16,7 @@ func init() {
 		Flags: []cli.Flag{
 			configFlag,
 			netNamesFlag,
+			noBrowserFlag,
 		},
 		Action: func(c *cli.Context) error {
 			res := resources.InitResources(c.String("config"))
@@ -26,7 +27,7 @@ func init() {
 			} else {
 				databases = res.MetaDB.GetAnalyzedDatabases()
 			}
-			err := reporting.PrintHTML(databases, c.Bool("network-names"), res)
+			err := reporting.PrintHTML(databases, c.Bool("network-names"), c.Bool("no-browser"), res)
 			if err != nil {
 				return cli.NewExitError(err.Error(), -1)
 			}

--- a/reporting/report.go
+++ b/reporting/report.go
@@ -20,7 +20,7 @@ import (
 // a directory named after the selected dataset, or `rita-html-report` if
 // mupltiple were selected, within the current working directory,
 // mongodb must be running to call this command, will exit on any writing error
-func PrintHTML(dbsIn []string, showNetNames bool, res *resources.Resources) error {
+func PrintHTML(dbsIn []string, showNetNames bool, noBrowser bool, res *resources.Resources) error {
 	if len(dbsIn) == 0 {
 		return errors.New("no analyzed databases to report on")
 	}
@@ -80,8 +80,10 @@ func PrintHTML(dbsIn []string, showNetNames bool, res *resources.Resources) erro
 	}
 
 	fmt.Println("[-] Wrote outputs, check " + wd + " for files")
-	os.Chdir("..")
-	open.Run("./" + outFolderString + "/index.html")
+	if !noBrowser {
+		os.Chdir("..")
+		open.Run("./" + outFolderString + "/index.html")
+	}
 	// End db iteration
 	return nil
 }


### PR DESCRIPTION
`--no-browser` / `-nb` boolean flag is added to `html-report` subcommand which allows users to prevent auto-launching the default browser.

Closes #593