### PR TITLE
make `--config` a global option on `rita` command

### DIFF
--- a/commands/commands.go
+++ b/commands/commands.go
@@ -13,7 +13,7 @@ var (
 
 	// below are some prebuilt flags that get used often in various commands
 
-	// configFlag allows users to specify an alternate config file to use
+	// ConfigFlag allows users to specify an alternate config file to use
 	ConfigFlag = cli.StringFlag{
 		Name:  "config, c",
 		Usage: "Use a given `CONFIG_FILE` when running this command",

--- a/commands/commands.go
+++ b/commands/commands.go
@@ -13,13 +13,6 @@ var (
 
 	// below are some prebuilt flags that get used often in various commands
 
-	// configFlag allows users to specify an alternate config file to use
-	configFlag = cli.StringFlag{
-		Name:  "config, c",
-		Usage: "Use a given `CONFIG_FILE` when running this command",
-		Value: "",
-	}
-
 	// forceFlag allows users to bypass prompts
 	forceFlag = cli.BoolFlag{
 		Name:  "force, f",
@@ -130,7 +123,7 @@ func bootstrapCommands(commands ...cli.Command) {
 	for _, command := range commands {
 		command.Before = func(c *cli.Context) error {
 			//Get access to the logger
-			configFile := c.String("config")
+			configFile := c.GlobalString("config")
 			res := resources.InitResources(configFile)
 			//Display args in logs
 			fields := log.Fields{

--- a/commands/commands.go
+++ b/commands/commands.go
@@ -13,6 +13,13 @@ var (
 
 	// below are some prebuilt flags that get used often in various commands
 
+	// configFlag allows users to specify an alternate config file to use
+	ConfigFlag = cli.StringFlag{
+		Name:  "config, c",
+		Usage: "Use a given `CONFIG_FILE` when running this command",
+		Value: "",
+	}
+
 	// forceFlag allows users to bypass prompts
 	forceFlag = cli.BoolFlag{
 		Name:  "force, f",
@@ -123,13 +130,34 @@ var (
 	}
 )
 
+// SetConfigFilePath reads config file path from cli context and stores it in app metadata
+// to make it available to all subcommands. The root command and all subcommands use this.
+// If --config flag is supplied for both root command and a subcommand, the value of the
+// subcommand is used.
+func SetConfigFilePath(c *cli.Context) error {
+	if configFilePath := c.String("config"); configFilePath != "" {
+		c.App.Metadata["config"] = configFilePath
+	}
+	return nil
+}
+
+// getConfigFilePath returns config file path from app metadata
+func getConfigFilePath(c *cli.Context) string {
+	switch cfg := c.App.Metadata["config"].(type) {
+	case string:
+		return cfg
+	default:
+		return ""
+	}
+}
+
 // bootstrapCommands simply adds a given command to the allCommands array
 func bootstrapCommands(commands ...cli.Command) {
 	for _, command := range commands {
 		command.Before = func(c *cli.Context) error {
 			//Get access to the logger
-			configFile := c.GlobalString("config")
-			res := resources.InitResources(configFile)
+			SetConfigFilePath(c)
+			res := resources.InitResources(getConfigFilePath(c))
 			//Display args in logs
 			fields := log.Fields{
 				"Arguments": c.Args(),

--- a/commands/delete-database.go
+++ b/commands/delete-database.go
@@ -21,7 +21,6 @@ func init() {
 		ArgsUsage: "<database>",
 		Flags: []cli.Flag{
 			forceFlag,
-			configFlag,
 			allFlag,
 			matchFlag,
 			regexFlag,
@@ -35,7 +34,7 @@ func init() {
 
 //deleteDatabase deletes a target database
 func deleteDatabase(c *cli.Context) error {
-	res := resources.InitResources(c.String("config"))
+	res := resources.InitResources(c.GlobalString("config"))
 
 	// Different command flags
 	tgt := c.Args().Get(0)

--- a/commands/delete-database.go
+++ b/commands/delete-database.go
@@ -20,6 +20,7 @@ func init() {
 		Usage:     "Delete imported database(s)",
 		ArgsUsage: "<database>",
 		Flags: []cli.Flag{
+			ConfigFlag,
 			forceFlag,
 			allFlag,
 			matchFlag,
@@ -34,7 +35,7 @@ func init() {
 
 //deleteDatabase deletes a target database
 func deleteDatabase(c *cli.Context) error {
-	res := resources.InitResources(c.GlobalString("config"))
+	res := resources.InitResources(getConfigFilePath(c))
 
 	// Different command flags
 	tgt := c.Args().Get(0)

--- a/commands/import.go
+++ b/commands/import.go
@@ -23,7 +23,6 @@ func init() {
 			" named <database name>.",
 		Flags: []cli.Flag{
 			threadFlag,
-			configFlag,
 			deleteFlag,
 			rollingFlag,
 			totalChunksFlag,
@@ -32,7 +31,7 @@ func init() {
 		Action: func(c *cli.Context) error {
 			importer := NewImporter(c)
 			err := importer.run()
-			fmt.Println(updateCheck(c.String("config")))
+			fmt.Println(updateCheck(c.GlobalString("config")))
 			return err
 		},
 	}
@@ -59,7 +58,7 @@ type (
 //NewImporter ....
 func NewImporter(c *cli.Context) *Importer {
 	return &Importer{
-		configFile:      c.String("config"),
+		configFile:      c.GlobalString("config"),
 		args:            c.Args(),
 		deleteOldData:   c.Bool("delete"),
 		userRolling:     c.Bool("rolling"),

--- a/commands/import.go
+++ b/commands/import.go
@@ -22,6 +22,7 @@ func init() {
 			"Logs directly in <import directory> will be imported into a database" +
 			" named <database name>.",
 		Flags: []cli.Flag{
+			ConfigFlag,
 			threadFlag,
 			deleteFlag,
 			rollingFlag,
@@ -31,7 +32,7 @@ func init() {
 		Action: func(c *cli.Context) error {
 			importer := NewImporter(c)
 			err := importer.run()
-			fmt.Println(updateCheck(c.GlobalString("config")))
+			fmt.Println(updateCheck(getConfigFilePath(c)))
 			return err
 		},
 	}
@@ -58,7 +59,7 @@ type (
 //NewImporter ....
 func NewImporter(c *cli.Context) *Importer {
 	return &Importer{
-		configFile:      c.GlobalString("config"),
+		configFile:      getConfigFilePath(c),
 		args:            c.Args(),
 		deleteOldData:   c.Bool("delete"),
 		userRolling:     c.Bool("rolling"),

--- a/commands/reporting.go
+++ b/commands/reporting.go
@@ -14,11 +14,10 @@ func init() {
 		UsageText: "rita html-report [command-options] [database]\n\n" +
 			"If no database is specified, a report will be created for every database.",
 		Flags: []cli.Flag{
-			configFlag,
 			netNamesFlag,
 		},
 		Action: func(c *cli.Context) error {
-			res := resources.InitResources(c.String("config"))
+			res := resources.InitResources(c.GlobalString("config"))
 			databaseName := c.Args().Get(0)
 			var databases []string
 			if databaseName != "" {

--- a/commands/reporting.go
+++ b/commands/reporting.go
@@ -14,11 +14,12 @@ func init() {
 		UsageText: "rita html-report [command-options] [database]\n\n" +
 			"If no database is specified, a report will be created for every database.",
 		Flags: []cli.Flag{
+			ConfigFlag,
 			netNamesFlag,
 			noBrowserFlag,
 		},
 		Action: func(c *cli.Context) error {
-			res := resources.InitResources(c.GlobalString("config"))
+			res := resources.InitResources(getConfigFilePath(c))
 			databaseName := c.Args().Get(0)
 			var databases []string
 			if databaseName != "" {

--- a/commands/show-beacons-fqdn.go
+++ b/commands/show-beacons-fqdn.go
@@ -18,7 +18,6 @@ func init() {
 		ArgsUsage: "<database>",
 		Flags: []cli.Flag{
 			humanFlag,
-			configFlag,
 			delimFlag,
 			netNamesFlag,
 		},
@@ -33,7 +32,7 @@ func showBeaconsFQDN(c *cli.Context) error {
 	if db == "" {
 		return cli.NewExitError("Specify a database", -1)
 	}
-	res := resources.InitResources(c.String("config"))
+	res := resources.InitResources(c.GlobalString("config"))
 	res.DB.SelectDB(db)
 
 	data, err := beaconfqdn.Results(res, 0)

--- a/commands/show-beacons-fqdn.go
+++ b/commands/show-beacons-fqdn.go
@@ -17,6 +17,7 @@ func init() {
 		Usage:     "Print hosts which show signs of C2 software (FQDN Analysis)",
 		ArgsUsage: "<database>",
 		Flags: []cli.Flag{
+			ConfigFlag,
 			humanFlag,
 			delimFlag,
 			netNamesFlag,
@@ -32,7 +33,7 @@ func showBeaconsFQDN(c *cli.Context) error {
 	if db == "" {
 		return cli.NewExitError("Specify a database", -1)
 	}
-	res := resources.InitResources(c.GlobalString("config"))
+	res := resources.InitResources(getConfigFilePath(c))
 	res.DB.SelectDB(db)
 
 	data, err := beaconfqdn.Results(res, 0)

--- a/commands/show-beacons.go
+++ b/commands/show-beacons.go
@@ -18,7 +18,6 @@ func init() {
 		ArgsUsage: "<database>",
 		Flags: []cli.Flag{
 			humanFlag,
-			configFlag,
 			delimFlag,
 			netNamesFlag,
 		},
@@ -33,7 +32,7 @@ func showBeacons(c *cli.Context) error {
 	if db == "" {
 		return cli.NewExitError("Specify a database", -1)
 	}
-	res := resources.InitResources(c.String("config"))
+	res := resources.InitResources(c.GlobalString("config"))
 	res.DB.SelectDB(db)
 
 	data, err := beacon.Results(res, 0)

--- a/commands/show-beacons.go
+++ b/commands/show-beacons.go
@@ -17,6 +17,7 @@ func init() {
 		Usage:     "Print hosts which show signs of C2 software",
 		ArgsUsage: "<database>",
 		Flags: []cli.Flag{
+			ConfigFlag,
 			humanFlag,
 			delimFlag,
 			netNamesFlag,
@@ -32,7 +33,7 @@ func showBeacons(c *cli.Context) error {
 	if db == "" {
 		return cli.NewExitError("Specify a database", -1)
 	}
-	res := resources.InitResources(c.GlobalString("config"))
+	res := resources.InitResources(getConfigFilePath(c))
 	res.DB.SelectDB(db)
 
 	data, err := beacon.Results(res, 0)

--- a/commands/show-bl-hostname.go
+++ b/commands/show-bl-hostname.go
@@ -20,7 +20,6 @@ func init() {
 		ArgsUsage: "<database>",
 		Flags: []cli.Flag{
 			humanFlag,
-			configFlag,
 			limitFlag,
 			noLimitFlag,
 			delimFlag,
@@ -40,7 +39,7 @@ func printBLHostnames(c *cli.Context) error {
 		return cli.NewExitError("Specify a database", -1)
 	}
 
-	res := resources.InitResources(c.String("config"))
+	res := resources.InitResources(c.GlobalString("config"))
 	res.DB.SelectDB(db)
 
 	data, err := blacklist.HostnameResults(res, "conn_count", c.Int("limit"), c.Bool("no-limit"))

--- a/commands/show-bl-hostname.go
+++ b/commands/show-bl-hostname.go
@@ -19,6 +19,7 @@ func init() {
 		Name:      "show-bl-hostnames",
 		ArgsUsage: "<database>",
 		Flags: []cli.Flag{
+			ConfigFlag,
 			humanFlag,
 			limitFlag,
 			noLimitFlag,
@@ -39,7 +40,7 @@ func printBLHostnames(c *cli.Context) error {
 		return cli.NewExitError("Specify a database", -1)
 	}
 
-	res := resources.InitResources(c.GlobalString("config"))
+	res := resources.InitResources(getConfigFilePath(c))
 	res.DB.SelectDB(db)
 
 	data, err := blacklist.HostnameResults(res, "conn_count", c.Int("limit"), c.Bool("no-limit"))

--- a/commands/show-bl-ip.go
+++ b/commands/show-bl-ip.go
@@ -18,6 +18,7 @@ func init() {
 		Name:      "show-bl-source-ips",
 		ArgsUsage: "<database>",
 		Flags: []cli.Flag{
+			ConfigFlag,
 			humanFlag,
 			blConnFlag,
 			blSortFlag,
@@ -34,6 +35,7 @@ func init() {
 		Name:      "show-bl-dest-ips",
 		ArgsUsage: "<database>",
 		Flags: []cli.Flag{
+			ConfigFlag,
 			humanFlag,
 			blConnFlag,
 			blSortFlag,
@@ -69,7 +71,7 @@ func printBLSourceIPs(c *cli.Context) error {
 	if err != nil {
 		return err
 	}
-	res := resources.InitResources(c.GlobalString("config"))
+	res := resources.InitResources(getConfigFilePath(c))
 	res.DB.SelectDB(db)
 
 	data, err := blacklist.SrcIPResults(res, sort, c.Int("limit"), c.Bool("no-limit"))
@@ -103,7 +105,7 @@ func printBLDestIPs(c *cli.Context) error {
 		return err
 	}
 
-	res := resources.InitResources(c.GlobalString("config"))
+	res := resources.InitResources(getConfigFilePath(c))
 	res.DB.SelectDB(db)
 
 	data, err := blacklist.DstIPResults(res, sort, c.Int("limit"), c.Bool("no-limit"))

--- a/commands/show-bl-ip.go
+++ b/commands/show-bl-ip.go
@@ -21,7 +21,6 @@ func init() {
 			humanFlag,
 			blConnFlag,
 			blSortFlag,
-			configFlag,
 			limitFlag,
 			noLimitFlag,
 			delimFlag,
@@ -38,7 +37,6 @@ func init() {
 			humanFlag,
 			blConnFlag,
 			blSortFlag,
-			configFlag,
 			limitFlag,
 			noLimitFlag,
 			delimFlag,
@@ -71,7 +69,7 @@ func printBLSourceIPs(c *cli.Context) error {
 	if err != nil {
 		return err
 	}
-	res := resources.InitResources(c.String("config"))
+	res := resources.InitResources(c.GlobalString("config"))
 	res.DB.SelectDB(db)
 
 	data, err := blacklist.SrcIPResults(res, sort, c.Int("limit"), c.Bool("no-limit"))
@@ -105,7 +103,7 @@ func printBLDestIPs(c *cli.Context) error {
 		return err
 	}
 
-	res := resources.InitResources(c.String("config"))
+	res := resources.InitResources(c.GlobalString("config"))
 	res.DB.SelectDB(db)
 
 	data, err := blacklist.DstIPResults(res, sort, c.Int("limit"), c.Bool("no-limit"))

--- a/commands/show-databases.go
+++ b/commands/show-databases.go
@@ -13,8 +13,11 @@ func init() {
 		Name:    "list",
 		Aliases: []string{"show-databases"},
 		Usage:   "Print the databases currently stored",
+		Flags: []cli.Flag{
+			ConfigFlag,
+		},
 		Action: func(c *cli.Context) error {
-			res := resources.InitResources(c.GlobalString("config"))
+			res := resources.InitResources(getConfigFilePath(c))
 
 			if res != nil {
 				for _, name := range res.MetaDB.GetDatabases() {

--- a/commands/show-databases.go
+++ b/commands/show-databases.go
@@ -13,11 +13,8 @@ func init() {
 		Name:    "list",
 		Aliases: []string{"show-databases"},
 		Usage:   "Print the databases currently stored",
-		Flags: []cli.Flag{
-			configFlag,
-		},
 		Action: func(c *cli.Context) error {
-			res := resources.InitResources(c.String("config"))
+			res := resources.InitResources(c.GlobalString("config"))
 
 			if res != nil {
 				for _, name := range res.MetaDB.GetDatabases() {

--- a/commands/show-explodedDns.go
+++ b/commands/show-explodedDns.go
@@ -20,7 +20,6 @@ func init() {
 		ArgsUsage: "<database>",
 		Flags: []cli.Flag{
 			humanFlag,
-			configFlag,
 			limitFlag,
 			noLimitFlag,
 			delimFlag,
@@ -31,7 +30,7 @@ func init() {
 				return cli.NewExitError("Specify a database", -1)
 			}
 
-			res := resources.InitResources(c.String("config"))
+			res := resources.InitResources(c.GlobalString("config"))
 			res.DB.SelectDB(db)
 
 			data, err := explodeddns.Results(res, c.Int("limit"), c.Bool("no-limit"))

--- a/commands/show-explodedDns.go
+++ b/commands/show-explodedDns.go
@@ -19,6 +19,7 @@ func init() {
 		Usage:     "Print dns analysis. Exposes covert dns channels",
 		ArgsUsage: "<database>",
 		Flags: []cli.Flag{
+			ConfigFlag,
 			humanFlag,
 			limitFlag,
 			noLimitFlag,
@@ -30,7 +31,7 @@ func init() {
 				return cli.NewExitError("Specify a database", -1)
 			}
 
-			res := resources.InitResources(c.GlobalString("config"))
+			res := resources.InitResources(getConfigFilePath(c))
 			res.DB.SelectDB(db)
 
 			data, err := explodeddns.Results(res, c.Int("limit"), c.Bool("no-limit"))

--- a/commands/show-long-connections.go
+++ b/commands/show-long-connections.go
@@ -19,6 +19,7 @@ func init() {
 		Usage:     "Print long connections and relevant information",
 		ArgsUsage: "<database>",
 		Flags: []cli.Flag{
+			ConfigFlag,
 			humanFlag,
 			limitFlag,
 			noLimitFlag,
@@ -31,7 +32,7 @@ func init() {
 				return cli.NewExitError("Specify a database", -1)
 			}
 
-			res := resources.InitResources(c.GlobalString("config"))
+			res := resources.InitResources(getConfigFilePath(c))
 			res.DB.SelectDB(db)
 
 			thresh := 60 // 1 minute

--- a/commands/show-long-connections.go
+++ b/commands/show-long-connections.go
@@ -20,7 +20,6 @@ func init() {
 		ArgsUsage: "<database>",
 		Flags: []cli.Flag{
 			humanFlag,
-			configFlag,
 			limitFlag,
 			noLimitFlag,
 			delimFlag,
@@ -32,7 +31,7 @@ func init() {
 				return cli.NewExitError("Specify a database", -1)
 			}
 
-			res := resources.InitResources(c.String("config"))
+			res := resources.InitResources(c.GlobalString("config"))
 			res.DB.SelectDB(db)
 
 			thresh := 60 // 1 minute

--- a/commands/show-strobes.go
+++ b/commands/show-strobes.go
@@ -23,7 +23,6 @@ func init() {
 				Name:  "connection-count, l",
 				Usage: "Sort the strobes by largest connection count.",
 			},
-			configFlag,
 			limitFlag,
 			noLimitFlag,
 			delimFlag,
@@ -35,7 +34,7 @@ func init() {
 				return cli.NewExitError("Specify a database", -1)
 			}
 
-			res := resources.InitResources(c.String("config"))
+			res := resources.InitResources(c.GlobalString("config"))
 			res.DB.SelectDB(db)
 
 			sortDirection := -1

--- a/commands/show-strobes.go
+++ b/commands/show-strobes.go
@@ -18,6 +18,7 @@ func init() {
 		Usage:     "Print strobe information",
 		ArgsUsage: "<database>",
 		Flags: []cli.Flag{
+			ConfigFlag,
 			humanFlag,
 			cli.BoolFlag{
 				Name:  "connection-count, l",
@@ -34,7 +35,7 @@ func init() {
 				return cli.NewExitError("Specify a database", -1)
 			}
 
-			res := resources.InitResources(c.GlobalString("config"))
+			res := resources.InitResources(getConfigFilePath(c))
 			res.DB.SelectDB(db)
 
 			sortDirection := -1

--- a/commands/show-user-agents.go
+++ b/commands/show-user-agents.go
@@ -23,7 +23,6 @@ func init() {
 				Name:  "least-used, l",
 				Usage: "Sort the user agents from least used to most used.",
 			},
-			configFlag,
 			limitFlag,
 			noLimitFlag,
 			delimFlag,
@@ -34,7 +33,7 @@ func init() {
 				return cli.NewExitError("Specify a database", -1)
 			}
 
-			res := resources.InitResources(c.String("config"))
+			res := resources.InitResources(c.GlobalString("config"))
 			res.DB.SelectDB(db)
 
 			sortDirection := 1

--- a/commands/show-user-agents.go
+++ b/commands/show-user-agents.go
@@ -18,6 +18,7 @@ func init() {
 		Usage:     "Print user agent information",
 		ArgsUsage: "<database>",
 		Flags: []cli.Flag{
+			ConfigFlag,
 			humanFlag,
 			cli.BoolFlag{
 				Name:  "least-used, l",
@@ -33,7 +34,7 @@ func init() {
 				return cli.NewExitError("Specify a database", -1)
 			}
 
-			res := resources.InitResources(c.GlobalString("config"))
+			res := resources.InitResources(getConfigFilePath(c))
 			res.DB.SelectDB(db)
 
 			sortDirection := 1

--- a/commands/test-config.go
+++ b/commands/test-config.go
@@ -13,15 +13,10 @@ import (
 
 func init() {
 	command := cli.Command{
-		Flags: []cli.Flag{
-			cli.StringFlag{
-				Name:  "config, c",
-				Usage: "specify a config file to be used",
-				Value: "",
-			},
-		},
+		Flags:  []cli.Flag{ConfigFlag},
 		Name:   "test-config",
 		Usage:  "Check the configuration file for validity",
+		Before: SetConfigFilePath,
 		Action: testConfiguration,
 	}
 
@@ -31,7 +26,7 @@ func init() {
 // testConfiguration prints out the result of parsing the config file
 func testConfiguration(c *cli.Context) error {
 	// First, print out the config as it was parsed
-	conf, err := config.LoadConfig(c.String("config"))
+	conf, err := config.LoadConfig(getConfigFilePath(c))
 	if err != nil {
 		fmt.Fprintf(os.Stdout, "Failed to config: %s\n", err.Error())
 		os.Exit(-1)
@@ -51,7 +46,7 @@ func testConfiguration(c *cli.Context) error {
 	fmt.Fprintf(os.Stdout, "\n%s\n", string(tableConfig))
 
 	// Then test initializing external resources like db connection and file handles
-	resources.InitResources(c.String("config"))
+	resources.InitResources(getConfigFilePath(c))
 
 	return nil
 }

--- a/commands/update-check.go
+++ b/commands/update-check.go
@@ -22,7 +22,7 @@ var versions = []string{"Major", "Minor", "Patch"}
 func GetVersionPrinter() func(*cli.Context) {
 	return func(c *cli.Context) {
 		fmt.Printf("%s version %s\n", c.App.Name, c.App.Version)
-		fmt.Println(updateCheck(c.GlobalString("config")))
+		fmt.Println(updateCheck(getConfigFilePath(c)))
 	}
 }
 

--- a/commands/update-check.go
+++ b/commands/update-check.go
@@ -22,7 +22,7 @@ var versions = []string{"Major", "Minor", "Patch"}
 func GetVersionPrinter() func(*cli.Context) {
 	return func(c *cli.Context) {
 		fmt.Printf("%s version %s\n", c.App.Name, c.App.Version)
-		fmt.Println(updateCheck(c.String("config")))
+		fmt.Println(updateCheck(c.GlobalString("config")))
 	}
 }
 

--- a/rita.go
+++ b/rita.go
@@ -14,14 +14,7 @@ func main() {
 	app := cli.NewApp()
 	app.Name = "rita"
 	app.Usage = "Look for evil needles in big haystacks."
-
-	// configFlag allows users to specify an alternate config file to use
-	configFlag := cli.StringFlag{
-		Name:  "config, c",
-		Usage: "Use a given `CONFIG_FILE` when running this command",
-		Value: "",
-	}
-	app.Flags = []cli.Flag{configFlag}
+	app.Flags = []cli.Flag{commands.ConfigFlag}
 
 	cli.VersionPrinter = commands.GetVersionPrinter()
 
@@ -32,6 +25,7 @@ func main() {
 
 	// Define commands used with this application
 	app.Commands = commands.Commands()
+	app.Before = commands.SetConfigFilePath
 
 	runtime.GOMAXPROCS(runtime.NumCPU())
 	app.Run(os.Args)

--- a/rita.go
+++ b/rita.go
@@ -15,6 +15,14 @@ func main() {
 	app.Name = "rita"
 	app.Usage = "Look for evil needles in big haystacks."
 
+	// configFlag allows users to specify an alternate config file to use
+	configFlag := cli.StringFlag{
+		Name:  "config, c",
+		Usage: "Use a given `CONFIG_FILE` when running this command",
+		Value: "",
+	}
+	app.Flags = []cli.Flag{configFlag}
+
 	cli.VersionPrinter = commands.GetVersionPrinter()
 
 	// Change the version string with updates so that a quick help command will


### PR DESCRIPTION
This PR does the following:
  * makes `--config` a global option on the `rita` command.
  * removes `--config` flag from subcommands (`import`, `html-report` etc.)
  * uses [`GlobalString`](https://github.com/urfave/cli/blob/v1.22.0/flag_generated.go#L709) to fetch config value from global state. For reference, see this [issue](https://github.com/urfave/cli/issues/716).


Closes #595