### PR TITLE
Fixed missing </td> in report-beacons.go and report-beaconsfqdn.go

### DIFF
--- a/reporting/report-beacons.go
+++ b/reporting/report-beacons.go
@@ -58,7 +58,7 @@ func getBeaconWriter(beacons []beacon.Result, showNetNames bool) (string, error)
 		tmpl += "<td>{{.SrcIP}}</td><td>{{.DstIP}}</td>"
 	}
 	tmpl += "<td>{{.Connections}}</td><td>{{printf \"%.3f\" .AvgBytes}}</td><td>"
-	tmpl += "{{.Ts.Range}}</td><td>{{.Ds.Range}}</td><td>{{.Ts.Mode}}</td><td>{{.Ds.Mode}}</td><td>{{.Ts.ModeCount}}</td><td>{{.Ds.ModeCount}}<td>"
+	tmpl += "{{.Ts.Range}}</td><td>{{.Ds.Range}}</td><td>{{.Ts.Mode}}</td><td>{{.Ds.Mode}}</td><td>{{.Ts.ModeCount}}</td><td>{{.Ds.ModeCount}}</td><td>"
 	tmpl += "{{printf \"%.3f\" .Ts.Skew}}</td><td>{{printf \"%.3f\" .Ds.Skew}}</td><td>{{.Ts.Dispersion}}</td><td>{{.Ds.Dispersion}}</td><td>{{.TotalBytes}}</td>"
 	tmpl += "</tr>\n"
 

--- a/reporting/report-beaconsfqdn.go
+++ b/reporting/report-beaconsfqdn.go
@@ -58,7 +58,7 @@ func getBeaconFQDNWriter(beaconsFQDN []beaconfqdn.Result, showNetNames bool) (st
 		tmpl += "<td>{{.SrcIP}}</td><td>{{.FQDN}}</td>"
 	}
 	tmpl += "<td>{{.Connections}}</td><td>{{printf \"%.3f\" .AvgBytes}}</td><td>"
-	tmpl += "{{.Ts.Range}}</td><td>{{.Ds.Range}}</td><td>{{.Ts.Mode}}</td><td>{{.Ds.Mode}}</td><td>{{.Ts.ModeCount}}</td><td>{{.Ds.ModeCount}}<td>"
+	tmpl += "{{.Ts.Range}}</td><td>{{.Ds.Range}}</td><td>{{.Ts.Mode}}</td><td>{{.Ds.Mode}}</td><td>{{.Ts.ModeCount}}</td><td>{{.Ds.ModeCount}}</td><td>"
 	tmpl += "{{printf \"%.3f\" .Ts.Skew}}</td><td>{{printf \"%.3f\" .Ds.Skew}}</td><td>{{.Ts.Dispersion}}</td><td>{{.Ds.Dispersion}}</td>"
 	tmpl += "</tr>\n"
 


### PR DESCRIPTION
Hi 

I've fixed a minor error in the html-export command.
This made the data very hard to parse with other tools, for instance pandas.
I've fixed it by adding the required `</td>` in the code after `.Ds.ModeCount`