### PR TITLE
Update Mongo Version to 4.2

### DIFF
--- a/database/db.go
+++ b/database/db.go
@@ -14,16 +14,16 @@ import (
 //MinMongoDBVersion is the lower, inclusive bound on the
 //versions of MongoDB compatible with RITA
 var MinMongoDBVersion = semver.Version{
-	Major: 3,
-	Minor: 6,
+	Major: 4,
+	Minor: 2,
 	Patch: 0,
 }
 
 //MaxMongoDBVersion is the upper, exclusive bound on the
 //versions of MongoDB compatible with RITA
 var MaxMongoDBVersion = semver.Version{
-	Major: 3,
-	Minor: 7,
+	Major: 4,
+	Minor: 3,
 	Patch: 0,
 }
 

--- a/install.sh
+++ b/install.sh
@@ -357,7 +357,7 @@ __intermediary_update_mongodb() {
         __configure_mongodb
 
         # Loop until service comes to life
-        while [ ! systemctl is-active --quiet mongod ]
+        while [ ! $(systemctl is-active --quiet mongod) ];
         do
             sleep 1
         done

--- a/install.sh
+++ b/install.sh
@@ -5,7 +5,8 @@
 
 # CONSTANTS
 _RITA_VERSION="v4.2.0"
-_MONGO_VERSION="3.6"
+_MONGO_VERSION="4.2"
+_MONGO_MIN_UPDATE_VERSION="4.0"
 _NAME=$(basename "${0}")
 _FAILED="\e[91mFAILED\e[0m"
 _SUCCESS="\e[92mSUCCESS\e[0m"
@@ -155,6 +156,13 @@ __install() {
         if [ "$_MONGO_INSTALLED" = "false" ]; then
             __load "$_ITEM Installing MongoDB" __install_mongodb
         elif ! __satisfies_version "$_MONGO_INSTALLED_VERSION" "$_MONGO_VERSION" ; then
+            # If Mongo is installed, check that it is 4.0 or above. Trying to update to v4.2
+            # from a version less than 4.0 will result in a bad day
+            if ! __satisfies_version() "$_MONGO_INSTALLED_VERSION" "$_MONGO_MIN_UPDATE_VERSION"; then
+                __mongo_upgrade_info
+                exit 1
+            fi
+
             __load "$_ITEM Updating MongoDB" __install_mongodb
             # Need to also install all the components of the mongodb-org metapackage for Ubuntu
             __install_packages mongodb-org-mongos mongodb-org-server mongodb-org-shell mongodb-org-tools
@@ -551,6 +559,12 @@ __explain() {
         printf "$_SUBITEM Update RITA at $_BIN_PATH/rita \n"
     fi
     sleep 5s
+}
+
+__mongo_upgrade_info() {
+    printf "$_IMPORTANT Cannot update to Mongo v4.2 from the currently installed Mongo Version of $_MONGO_INSTALLED_VERSION \n"
+    printf "$_IMPORTANT First upgrade to Mongo v4.0 and then re-run this installer or manually upgrade to Mongo v4.2 \n"
+    printf "$_IMPORTANT https://docs.mongodb.com/manual/release-notes/4.2-upgrade-standalone/ \n"
 }
 
 __title() {

--- a/install.sh
+++ b/install.sh
@@ -347,7 +347,7 @@ __intermediary_update_mongodb() {
     # such as the console version not matching the server version
     systemctl is-active --quiet mongod && systemctl stop mongod
 
-    __load __install_mongodb "$_MONGO_MIN_UPDATE_VERSION"
+    __install_mongodb "$_MONGO_MIN_UPDATE_VERSION"
 
     # Need to also install all the components of the mongodb-org metapackage for Ubuntu
     __install_packages mongodb-org-mongos mongodb-org-server mongodb-org-shell mongodb-org-tools

--- a/install.sh
+++ b/install.sh
@@ -158,7 +158,7 @@ __install() {
         elif ! __satisfies_version "$_MONGO_INSTALLED_VERSION" "$_MONGO_VERSION" ; then
             # If Mongo is installed, check that it is 4.0 or above. Trying to update to v4.2
             # from a version less than 4.0 will result in a bad day
-            if ! __satisfies_version() "$_MONGO_INSTALLED_VERSION" "$_MONGO_MIN_UPDATE_VERSION"; then
+            if ! __satisfies_version "$_MONGO_INSTALLED_VERSION" "$_MONGO_MIN_UPDATE_VERSION"; then
                 __mongo_upgrade_info
                 exit 1
             fi

--- a/install.sh
+++ b/install.sh
@@ -165,7 +165,7 @@ __install() {
 
             # Need to stop mongo before updating otherwise we can end up with weird issues,
             # such as the console version not matching the server version
-            systemctl stop mongo
+            systemctl is-active --quiet mongod && systemctl stop mongod
 
             __load "$_ITEM Updating MongoDB" __install_mongodb "$_MONGO_VERSION"
             # Need to also install all the components of the mongodb-org metapackage for Ubuntu
@@ -345,7 +345,7 @@ __add_zeek_to_path() {
 __intermediary_update_mongodb() {
     # Need to stop mongo before updating otherwise we can end up with weird issues,
     # such as the console version not matching the server version
-    systemctl stop mongo
+    systemctl is-active --quiet mongod && systemctl stop mongod
 
     __load __install_mongodb "$_MONGO_MIN_UPDATE_VERSION"
 

--- a/install.sh
+++ b/install.sh
@@ -436,13 +436,6 @@ __gather_OS() {
         printf "$_IMPORTANT Your operating system is unsupported."
         exit 1
     fi
-
-    # There is no official repository for Mongo3.6 on Ubuntu 18.04 Bionic.
-    # Documentation recommends using the xenial codename in repos to install Mongo 3.6:
-    # https://linuxconfig.org/how-to-install-latest-mongodb-on-ubuntu-18-04-bionic-beaver-linux
-    if [ "$_MONGO_OS_CODENAME" == "bionic" ]; then
-        _MONGO_OS_CODENAME="xenial"
-    fi
 }
 
 __gather_pkg_mgr() {

--- a/install.sh
+++ b/install.sh
@@ -188,7 +188,7 @@ __install() {
              
             # Set compatibility version in case we updated Mongo. It's fine to do this even if we didn't
             # update Mongo...it's just a bit cleaner to do it here to cut down on code redundancy and logic checks
-            __load "$ITEM Setting Mongo feature compatibility to $_MONGO_VERSION" __update_feature_compatibility "$_MONGO_VERSION"
+            __load "$_ITEM Setting Mongo feature compatibility to $_MONGO_VERSION" __update_feature_compatibility "$_MONGO_VERSION"
         fi
     fi
 
@@ -387,7 +387,7 @@ __intermediary_update_mongodb() {
 
         # Need to update feature compatibility to 4.0 otherwise things will break when we update
         # to 4.2
-        __load "$ITEM Setting feature compatibility in Mongo to $_MONGO_MIN_UPDATE_VERSION" __update_feature_compatibility "$_MONGO_MIN_UPDATE_VERSION"
+        __load "$_ITEM Setting feature compatibility in Mongo to $_MONGO_MIN_UPDATE_VERSION" __update_feature_compatibility "$_MONGO_MIN_UPDATE_VERSION"
     fi
 }
 

--- a/install.sh
+++ b/install.sh
@@ -357,7 +357,7 @@ __intermediary_update_mongodb() {
         __configure_mongodb
 
         # Loop until service comes to life
-        while [ ! $(systemctl is-active --quiet mongod) ];
+        while ! $(systemctl is-active --quiet mongod);
         do
             sleep 1
         done

--- a/install.sh
+++ b/install.sh
@@ -156,6 +156,10 @@ __install() {
         if [ "$_MONGO_INSTALLED" = "false" ]; then
             __load "$_ITEM Installing MongoDB" __install_mongodb "$_MONGO_VERSION" 
         elif ! __satisfies_version "$_MONGO_INSTALLED_VERSION" "$_MONGO_VERSION" ; then
+
+            # Check that the user wants to upgrade
+            __mongo_upgrade_info
+
             # Check if the version is less than 4.0. If so, we need to update to 4.0
             # before going to 4.2
             if ! __satisfies_version "$_MONGO_INSTALLED_VERSION" "$_MONGO_MIN_UPDATE_VERSION"; then
@@ -340,6 +344,18 @@ __add_zeek_to_path() {
     _ZEEK_PATH_SCRIPT_INSTALLED=true
     export PATH="$PATH:$_ZEEK_PATH"
     _ZEEK_IN_PATH=true
+}
+
+__mongo_upgrade_info() {
+    printf "$_IMPORTANT Mongo is already installed and is version $_MONGO_INSTALLED_VERSION.\n"
+    printf "$_IMPORTANT This will upgrade Mongo to version $_MONGO_VERSION.\n"
+    printf "$_IMPORTANT Note that Mongo must be upgraded to  $_MONGO_INSTALLED_VERSION for RITA $_RITA_VERSION to work.\n"
+    printf "$_IMPORTANT We suggest creating a backup of your data before upgrading (https://docs.mongodb.com/manual/tutorial/backup-and-restore-tools/).\n"
+    printf "$_QUESTION Would you like to upgrade your Mongo instance [y/N] "
+    read -e
+    if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+        exit 0
+    fi
 }
 
 __intermediary_update_mongodb() {
@@ -583,12 +599,6 @@ __explain() {
         printf "$_SUBITEM Update RITA at $_BIN_PATH/rita \n"
     fi
     sleep 5s
-}
-
-__mongo_upgrade_info() {
-    printf "$_IMPORTANT Cannot update to Mongo v4.2 from the currently installed Mongo Version of $_MONGO_INSTALLED_VERSION \n"
-    printf "$_IMPORTANT First upgrade to Mongo v4.0 and then re-run this installer or manually upgrade to Mongo v4.2 \n"
-    printf "$_IMPORTANT https://docs.mongodb.com/manual/release-notes/4.2-upgrade-standalone/ \n"
 }
 
 __title() {

--- a/install.sh
+++ b/install.sh
@@ -356,15 +356,12 @@ __intermediary_update_mongodb() {
         # Star and configure the service so that we can run the command to update feature compatibility
         __configure_mongodb
 
-        # Loop until service comes to life
-        while ! $(systemctl is-active --quiet mongod);
-        do
-            sleep 1
-        done
+        # Wait for service to come to life
+        sleep 10
 
         # Need to update feature compatibility to 4.0 otherwise things will break when we update
-        # to 4.2
-        mongo --eval "db.adminCommand( { setFeatureCompatibilityVersion: '$_MONGO_MIN_UPDATE_VERSION' } )"
+        # to 4.2. Hardcoded for now, can fix this later
+        mongo --eval 'db.adminCommand( { setFeatureCompatibilityVersion: "4.0" } )'
     fi
 }
 

--- a/install.sh
+++ b/install.sh
@@ -349,7 +349,7 @@ __add_zeek_to_path() {
 __mongo_upgrade_info() {
     printf "$_IMPORTANT Mongo is already installed and is version $_MONGO_INSTALLED_VERSION.\n"
     printf "$_IMPORTANT This will upgrade Mongo to version $_MONGO_VERSION.\n"
-    printf "$_IMPORTANT Note that Mongo must be upgraded to  $_MONGO_INSTALLED_VERSION for RITA $_RITA_VERSION to work.\n"
+    printf "$_IMPORTANT Note that Mongo must be upgraded to $_MONGO_INSTALLED_VERSION for RITA $_RITA_VERSION to work.\n"
     printf "$_IMPORTANT We suggest creating a backup of your data before upgrading (https://docs.mongodb.com/manual/tutorial/backup-and-restore-tools/).\n"
     printf "$_QUESTION Would you like to upgrade your Mongo instance [y/N] "
     read -e
@@ -382,7 +382,7 @@ __intermediary_update_mongodb() {
 }
 
 __update_feature_compatibility() {
-    mongo --eval 'db.adminCommand( { setFeatureCompatibilityVersion: "4.0" } )' --quiet
+    mongo --eval 'db.adminCommand( { setFeatureCompatibilityVersion: "4.0" } )' > /dev/null
 }
 
 __install_mongodb() {

--- a/install.sh
+++ b/install.sh
@@ -356,6 +356,12 @@ __intermediary_update_mongodb() {
         # Star and configure the service so that we can run the command to update feature compatibility
         __configure_mongodb
 
+        # Loop until service comes to life
+        while [ ! systemctl is-active --quiet mongod ]
+        do
+            sleep 1
+        done
+
         # Need to update feature compatibility to 4.0 otherwise things will break when we update
         # to 4.2
         mongo --eval "db.adminCommand( { setFeatureCompatibilityVersion: '$_MONGO_MIN_UPDATE_VERSION' } )"

--- a/install.sh
+++ b/install.sh
@@ -360,9 +360,13 @@ __intermediary_update_mongodb() {
         sleep 10
 
         # Need to update feature compatibility to 4.0 otherwise things will break when we update
-        # to 4.2. Hardcoded for now, can fix this later
-        mongo --eval 'db.adminCommand( { setFeatureCompatibilityVersion: "4.0" } )'
+        # to 4.2
+        __load "$ITEM Updating feature comapibility in Mongo to 4.0" __update_feature_compatibility
     fi
+}
+
+__update_feature_compatibility() {
+    mongo --eval 'db.adminCommand( { setFeatureCompatibilityVersion: "4.0" } )' --quiet
 }
 
 __install_mongodb() {

--- a/install.sh
+++ b/install.sh
@@ -349,7 +349,7 @@ __add_zeek_to_path() {
 __mongo_upgrade_info() {
     printf "$_IMPORTANT Mongo is already installed and is version $_MONGO_INSTALLED_VERSION.\n"
     printf "$_IMPORTANT This will upgrade Mongo to version $_MONGO_VERSION.\n"
-    printf "$_IMPORTANT Note that Mongo must be upgraded to $_MONGO_INSTALLED_VERSION for RITA $_RITA_VERSION to work.\n"
+    printf "$_IMPORTANT Note that Mongo must be upgraded to $_MONGO_VERSION for RITA $_RITA_VERSION to work.\n"
     printf "$_IMPORTANT We suggest creating a backup of your data before upgrading (https://docs.mongodb.com/manual/tutorial/backup-and-restore-tools/).\n"
     printf "$_QUESTION Would you like to upgrade your Mongo instance [y/N] "
     read -e


### PR DESCRIPTION
This PR is to update to Mongo version 4.2.

It will check if the user currently has Mongo installed. If so, it will check if it is less than version 4.0. If so, it will first upgrade to 4.0 and then upgrade to 4.2.  It will set the feature compatibility in Mongo to 4.0 after upgrading to 4.0 but before upgrading to 4.2.

If 4.0 is already installed, it will upgrade directly to 4.2.

If no Mongo version is installed, it will cleanly install 4.2.

The user will be prompted before upgrading from a prior version of Mongo and will be encouraged to create a backup of their data before proceeding.

Closes #651 