### PR TITLE
Add timestamp to HTML report templates

### DIFF
--- a/reporting/report-beacons.go
+++ b/reporting/report-beacons.go
@@ -10,7 +10,7 @@ import (
 	"github.com/activecm/rita/resources"
 )
 
-func printBeacons(db string, showNetNames bool, res *resources.Resources) error {
+func printBeacons(db string, showNetNames bool, res *resources.Resources, logsGeneratedAt string) error {
 	var w string
 	f, err := os.Create("beacons.html")
 	if err != nil {
@@ -44,7 +44,7 @@ func printBeacons(db string, showNetNames bool, res *resources.Resources) error 
 		}
 	}
 
-	return out.Execute(f, &templates.ReportingInfo{DB: db, Writer: template.HTML(w)})
+	return out.Execute(f, &templates.ReportingInfo{DB: db, Writer: template.HTML(w), LogsGeneratedAt: logsGeneratedAt})
 }
 
 func getBeaconWriter(beacons []beacon.Result, showNetNames bool) (string, error) {

--- a/reporting/report-beaconsfqdn.go
+++ b/reporting/report-beaconsfqdn.go
@@ -10,7 +10,7 @@ import (
 	"github.com/activecm/rita/resources"
 )
 
-func printBeaconsFQDN(db string, showNetNames bool, res *resources.Resources) error {
+func printBeaconsFQDN(db string, showNetNames bool, res *resources.Resources, logsGeneratedAt string) error {
 	var w string
 	f, err := os.Create("beaconsfqdn.html")
 	if err != nil {
@@ -44,7 +44,7 @@ func printBeaconsFQDN(db string, showNetNames bool, res *resources.Resources) er
 		}
 	}
 
-	return out.Execute(f, &templates.ReportingInfo{DB: db, Writer: template.HTML(w)})
+	return out.Execute(f, &templates.ReportingInfo{DB: db, Writer: template.HTML(w), LogsGeneratedAt: logsGeneratedAt})
 }
 
 func getBeaconFQDNWriter(beaconsFQDN []beaconfqdn.Result, showNetNames bool) (string, error) {

--- a/reporting/report-beaconsproxy.go
+++ b/reporting/report-beaconsproxy.go
@@ -10,7 +10,7 @@ import (
 	"github.com/activecm/rita/resources"
 )
 
-func printBeaconsProxy(db string, showNetNames bool, res *resources.Resources) error {
+func printBeaconsProxy(db string, showNetNames bool, res *resources.Resources, logsGeneratedAt string) error {
 	var w string
 	f, err := os.Create("beaconsproxy.html")
 	if err != nil {
@@ -44,7 +44,7 @@ func printBeaconsProxy(db string, showNetNames bool, res *resources.Resources) e
 		}
 	}
 
-	return out.Execute(f, &templates.ReportingInfo{DB: db, Writer: template.HTML(w)})
+	return out.Execute(f, &templates.ReportingInfo{DB: db, Writer: template.HTML(w), LogsGeneratedAt: logsGeneratedAt})
 }
 
 func getBeaconProxyWriter(beaconsProxy []beaconproxy.Result, showNetNames bool) (string, error) {

--- a/reporting/report-bl-dest-ips.go
+++ b/reporting/report-bl-dest-ips.go
@@ -9,7 +9,7 @@ import (
 	"github.com/activecm/rita/resources"
 )
 
-func printBLDestIPs(db string, showNetNames bool, res *resources.Resources) error {
+func printBLDestIPs(db string, showNetNames bool, res *resources.Resources, logsGeneratedAt string) error {
 	f, err := os.Create("bl-dest-ips.html")
 	if err != nil {
 		return err
@@ -38,5 +38,5 @@ func printBLDestIPs(db string, showNetNames bool, res *resources.Resources) erro
 		return err
 	}
 
-	return out.Execute(f, &templates.ReportingInfo{DB: db, Writer: template.HTML(w)})
+	return out.Execute(f, &templates.ReportingInfo{DB: db, Writer: template.HTML(w), LogsGeneratedAt: logsGeneratedAt})
 }

--- a/reporting/report-bl-hostnames.go
+++ b/reporting/report-bl-hostnames.go
@@ -12,7 +12,7 @@ import (
 	"github.com/activecm/rita/resources"
 )
 
-func printBLHostnames(db string, showNetNames bool, res *resources.Resources) error {
+func printBLHostnames(db string, showNetNames bool, res *resources.Resources, logsGeneratedAt string) error {
 	f, err := os.Create("bl-hostnames.html")
 	if err != nil {
 		return err
@@ -34,7 +34,7 @@ func printBLHostnames(db string, showNetNames bool, res *resources.Resources) er
 		return err
 	}
 
-	return out.Execute(f, &templates.ReportingInfo{DB: db, Writer: template.HTML(w)})
+	return out.Execute(f, &templates.ReportingInfo{DB: db, Writer: template.HTML(w), LogsGeneratedAt: logsGeneratedAt})
 }
 
 func getBLHostnameWriter(results []blacklist.HostnameResult, showNetNames bool) (string, error) {

--- a/reporting/report-bl-source-ips.go
+++ b/reporting/report-bl-source-ips.go
@@ -12,7 +12,7 @@ import (
 	"github.com/activecm/rita/resources"
 )
 
-func printBLSourceIPs(db string, showNetNames bool, res *resources.Resources) error {
+func printBLSourceIPs(db string, showNetNames bool, res *resources.Resources, logsGeneratedAt string) error {
 	f, err := os.Create("bl-source-ips.html")
 	if err != nil {
 		return err
@@ -41,7 +41,7 @@ func printBLSourceIPs(db string, showNetNames bool, res *resources.Resources) er
 		return err
 	}
 
-	return out.Execute(f, &templates.ReportingInfo{DB: db, Writer: template.HTML(w)})
+	return out.Execute(f, &templates.ReportingInfo{DB: db, Writer: template.HTML(w), LogsGeneratedAt: logsGeneratedAt})
 }
 
 func getBLIPWriter(results []blacklist.IPResult, showNetNames bool) (string, error) {

--- a/reporting/report-explodedDns.go
+++ b/reporting/report-explodedDns.go
@@ -10,7 +10,7 @@ import (
 	"github.com/activecm/rita/resources"
 )
 
-func printDNS(db string, showNetNames bool, res *resources.Resources) error {
+func printDNS(db string, showNetNames bool, res *resources.Resources, logsGeneratedAt string) error {
 	f, err := os.Create("dns.html")
 	if err != nil {
 		return err
@@ -36,7 +36,7 @@ func printDNS(db string, showNetNames bool, res *resources.Resources) error {
 		return err
 	}
 
-	return out.Execute(f, &templates.ReportingInfo{DB: db, Writer: template.HTML(w)})
+	return out.Execute(f, &templates.ReportingInfo{DB: db, Writer: template.HTML(w), LogsGeneratedAt: logsGeneratedAt})
 }
 
 func getDNSWriter(results []explodeddns.Result) (string, error) {

--- a/reporting/report-long-connections.go
+++ b/reporting/report-long-connections.go
@@ -11,7 +11,7 @@ import (
 	"github.com/activecm/rita/resources"
 )
 
-func printLongConns(db string, showNetNames bool, res *resources.Resources) error {
+func printLongConns(db string, showNetNames bool, res *resources.Resources, logsGeneratedAt string) error {
 	f, err := os.Create("long-conns.html")
 	if err != nil {
 		return err
@@ -42,7 +42,8 @@ func printLongConns(db string, showNetNames bool, res *resources.Resources) erro
 	if err != nil {
 		return err
 	}
-	return out.Execute(f, &templates.ReportingInfo{DB: db, Writer: template.HTML(w)})
+
+	return out.Execute(f, &templates.ReportingInfo{DB: db, Writer: template.HTML(w), LogsGeneratedAt: logsGeneratedAt})
 }
 
 func getLongConnWriter(conns []uconn.LongConnResult, showNetNames bool) (string, error) {

--- a/reporting/report-strobes.go
+++ b/reporting/report-strobes.go
@@ -10,7 +10,7 @@ import (
 	"github.com/activecm/rita/resources"
 )
 
-func printStrobes(db string, showNetNames bool, res *resources.Resources) error {
+func printStrobes(db string, showNetNames bool, res *resources.Resources, logsGeneratedAt string) error {
 	f, err := os.Create("strobes.html")
 	if err != nil {
 		return err
@@ -38,7 +38,8 @@ func printStrobes(db string, showNetNames bool, res *resources.Resources) error 
 	if err != nil {
 		return err
 	}
-	return out.Execute(f, &templates.ReportingInfo{DB: db, Writer: template.HTML(w)})
+
+	return out.Execute(f, &templates.ReportingInfo{DB: db, Writer: template.HTML(w), LogsGeneratedAt: logsGeneratedAt})
 }
 
 func getStrobesWriter(strobes []beacon.StrobeResult, showNetNames bool) (string, error) {

--- a/reporting/report-useragents.go
+++ b/reporting/report-useragents.go
@@ -10,7 +10,7 @@ import (
 	"github.com/activecm/rita/resources"
 )
 
-func printUserAgents(db string, showNetNames bool, res *resources.Resources) error {
+func printUserAgents(db string, showNetNames bool, res *resources.Resources, logsGeneratedAt string) error {
 	f, err := os.Create("useragents.html")
 	if err != nil {
 		return err
@@ -30,7 +30,8 @@ func printUserAgents(db string, showNetNames bool, res *resources.Resources) err
 	if err != nil {
 		return err
 	}
-	return out.Execute(f, &templates.ReportingInfo{DB: db, Writer: template.HTML(w)})
+
+	return out.Execute(f, &templates.ReportingInfo{DB: db, Writer: template.HTML(w), LogsGeneratedAt: logsGeneratedAt})
 }
 
 func getUserAgentsWriter(agents []useragent.Result) (string, error) {

--- a/reporting/report.go
+++ b/reporting/report.go
@@ -145,11 +145,7 @@ func writeDB(db string, wd string, showNetNames bool, res *resources.Resources) 
 	}
 	res.DB.SelectDB(db)
 
-	dbMetaInfo, err := res.MetaDB.GetDBMetaInfo(db)
-	if err != nil {
-		return err
-	}
-	maxTime := time.Unix(dbMetaInfo.TsRange.Max, 0).String()
+	maxTime := time.Now().Format(time.RFC1123)
 
 
 	err = writeDBHomePage(db, maxTime)

--- a/reporting/report.go
+++ b/reporting/report.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"os"
 	"strconv"
+	"time"
 
 	htmlTempl "github.com/activecm/rita/reporting/templates"
 	"github.com/activecm/rita/resources"
@@ -112,7 +113,7 @@ func writeHomePage(Dbs []string) error {
 	return out.Execute(f, Dbs)
 }
 
-func writeDBHomePage(db string) error {
+func writeDBHomePage(db string, logsGeneratedAt string) error {
 	f, err := os.Create("index.html")
 	if err != nil {
 		return err
@@ -124,7 +125,7 @@ func writeDBHomePage(db string) error {
 		return err
 	}
 
-	return out.Execute(f, htmlTempl.ReportingInfo{DB: db})
+	return out.Execute(f, htmlTempl.ReportingInfo{DB: db, LogsGeneratedAt: logsGeneratedAt})
 }
 
 func writeDB(db string, wd string, showNetNames bool, res *resources.Resources) error {
@@ -144,53 +145,60 @@ func writeDB(db string, wd string, showNetNames bool, res *resources.Resources) 
 	}
 	res.DB.SelectDB(db)
 
-	err = writeDBHomePage(db)
+	dbMetaInfo, err := res.MetaDB.GetDBMetaInfo(db)
+	if err != nil {
+		return err
+	}
+	maxTime := time.Unix(dbMetaInfo.TsRange.Max, 0).String()
+
+
+	err = writeDBHomePage(db, maxTime)
 	if err != nil {
 		fmt.Println("[-] Error writing Home page: " + err.Error())
 	}
 
-	err = printDNS(db, showNetNames, res)
+	err = printDNS(db, showNetNames, res, maxTime)
 	if err != nil {
 		fmt.Println("[-] Error writing DNS page: " + err.Error())
 	}
-	err = printBLSourceIPs(db, showNetNames, res)
+	err = printBLSourceIPs(db, showNetNames, res, maxTime)
 	if err != nil {
 		fmt.Println("[-] Error writing blacklist-source page: " + err.Error())
 	}
-	err = printBLDestIPs(db, showNetNames, res)
+	err = printBLDestIPs(db, showNetNames, res, maxTime)
 	if err != nil {
 		fmt.Println("[-] Error writing blacklist-destination page: " + err.Error())
 	}
-	err = printBLHostnames(db, showNetNames, res)
+	err = printBLHostnames(db, showNetNames, res, maxTime)
 	if err != nil {
 		fmt.Println("[-] Error writing blacklist-hostnames page: " + err.Error())
 	}
 
-	err = printBeacons(db, showNetNames, res)
+	err = printBeacons(db, showNetNames, res, maxTime)
 	if err != nil {
 		fmt.Println("[-] Error writing beacons page: " + err.Error())
 	}
 
-	err = printBeaconsFQDN(db, showNetNames, res)
+	err = printBeaconsFQDN(db, showNetNames, res, maxTime)
 	if err != nil {
 		fmt.Println("[-] Error writing beaconsFQDN page: " + err.Error())
 	}
 
-	err = printBeaconsProxy(db, showNetNames, res)
+	err = printBeaconsProxy(db, showNetNames, res, maxTime)
 	if err != nil {
 		fmt.Println("[-] Error writing beaconsProxy page: " + err.Error())
 	}
 
-	err = printStrobes(db, showNetNames, res)
+	err = printStrobes(db, showNetNames, res, maxTime)
 	if err != nil {
 		fmt.Println("[-] Error writing strobes page: " + err.Error())
 	}
 
-	err = printLongConns(db, showNetNames, res)
+	err = printLongConns(db, showNetNames, res, maxTime)
 	if err != nil {
 		fmt.Println("[-] Error writing long connections page: " + err.Error())
 	}
-	err = printUserAgents(db, showNetNames, res)
+	err = printUserAgents(db, showNetNames, res, maxTime)
 	if err != nil {
 		fmt.Println("[-] Error writing user agents page: " + err.Error())
 	}

--- a/reporting/templates/templates.go
+++ b/reporting/templates/templates.go
@@ -5,6 +5,7 @@ import "html/template"
 //ReportingInfo fills the templates listed in html/template
 type ReportingInfo struct {
 	DB     string
+  LogsGeneratedAt string
 	Writer template.HTML
 }
 
@@ -33,6 +34,7 @@ var dbHeader = `
 	<li><a href="bl-hostnames.html">BL Hostnames</a></li>
 	<li><a href="long-conns.html">Long Connections</a></li>
 	<li><a href="useragents.html">User Agents</a></li>
+  <li><a href="index.html">Time Generated: {{.LogsGeneratedAt}}</a></li>
 	<li style="float:right">
     <a href="https://github.com/activecm/rita" target="_blank">RITA on
 		<img src="../github.svg" title="Icon made by Dave Gandy from www.flaticon.com" id="github">


### PR DESCRIPTION
This adds a date/time block to the top bar of the HTML report representing the `maxTime` of the generated logs. The timestamp is visible from all panels in the HTML report.

Closes #594 