### PR TITLE
Add unique indexes to `beaconFQDN` and `beaconProxy` collections

### DIFF
--- a/pkg/beaconfqdn/mongodb.go
+++ b/pkg/beaconfqdn/mongodb.go
@@ -49,6 +49,7 @@ func (r *repo) CreateIndexes() error {
 	// set desired indexes
 	indexes := []mgo.Index{
 		{Key: []string{"-score"}},
+		{Key: []string{"src", "fqdn", "src_network_uuid"}, Unique: true},
 		{Key: []string{"src", "src_network_uuid"}},
 		{Key: []string{"fqdn"}},
 		{Key: []string{"-connection_count"}},


### PR DESCRIPTION
Fixes #688

Adds the necessary unique indexes to cover the upserts performed in the fqdn and proxy beacon analyses. 

Running a `.explain` for the FQDN beacon selector (see #688) now returns the following plan without a filter stage:
![image](https://user-images.githubusercontent.com/761220/128963327-a7c927ed-bf6a-42e3-abe1-5cae7996bc96.png)
