### PR TITLE
Drop stobe limit down to 86400 

### DIFF
--- a/config/static.go
+++ b/config/static.go
@@ -121,7 +121,7 @@ type (
 
 	//StrobeStaticCfg controls the maximum number of connections between any two given hosts
 	StrobeStaticCfg struct {
-		ConnectionLimit int `yaml:"ConnectionLimit" default:"250000"`
+		ConnectionLimit int `yaml:"ConnectionLimit" default:"86400"`
 	}
 )
 

--- a/etc/rita.yaml
+++ b/etc/rita.yaml
@@ -82,13 +82,13 @@ Filtering:
     - 10.0.0.0/8 # Private-Use Networks  RFC 1918
     - 172.16.0.0/12 # Private-Use Networks  RFC 1918
     - 192.168.0.0/16 # Private-Use Networks  RFC 1918
-  
+
   # Example: AlwaysIncludeDomain: ["mydomain.com","*.mydomain.com"]
-  # This functionality overrides the NeverIncludeDomain 
+  # This functionality overrides the NeverIncludeDomain
   # section, making sure that any connection records containing domains
   # that match this list are kept and not filtered
   # NOTE: When using wildcards, make sure the added entry is in quotes,
-  #       ie, '*.mydomain.com'. Only subdomain wildcarding 
+  #       ie, '*.mydomain.com'. Only subdomain wildcarding
   #       (asterisk as the prefix) is supported
   AlwaysIncludeDomain: []
 
@@ -96,10 +96,10 @@ Filtering:
   # This functions as a whitelisting setting, and connections involving
   # ranges entered into this section are filtered out at import time
   # NOTE: When using wildcards, make sure the added entry is in quotes,
-  #       ie, '*.mydomain.com'. Only subdomain wildcarding 
+  #       ie, '*.mydomain.com'. Only subdomain wildcarding
   #       (asterisk as the prefix) is supported
   NeverIncludeDomain: []
-  
+
 BlackListed:
   Enabled: true
   # These are blacklists built into rita-blacklist. Set these to false
@@ -178,8 +178,7 @@ Strobe:
   # analysis time, increase false positives, but reduce the risk of false negatives.
   # Recommended values for this setting are:
   #    86400 - One connection every second for 24 hours
-  #   250000 - (Default) Good middle of the road value
   #   700000 - Safe max value that is unlikely to cause errors
   # The theoretical limit due to implementation limitations is ~1,048,573
   # but in practice timeouts have occurred at lower values.
-  ConnectionLimit: 250000
+  ConnectionLimit: 86400


### PR DESCRIPTION
Fixes #696

Assuming the parsed in dataset represents a day, this drops the strobe limit to 1 connection per second. 

If any pair of hosts is connecting one per second, we want to bring this to the user's attention regardless of the beacon score. Additionally, this prevents RITA from running the beacon analysis modules on very large lists of connections.