### PR TITLE
709 ip6 arpa

### DIFF
--- a/parser/dns.go
+++ b/parser/dns.go
@@ -38,7 +38,7 @@ func parseDNSEntry(parseDNS *parsetypes.DNS, filter filter, retVals ParseResults
 	// in some of these strings, the empty space will get counted as a domain,
 	// don't add host or increment dns query count if queried domain
 	// is blank or ends in 'in-addr.arpa' or 'ip6.arpa'
-	if (parseDNS.Query != "") && (!strings.HasSuffix(parseDNS.Query, "in-addr.arpa")) && (!strings.HasSuffix(parseDNS.query, "ip6.arpa")) {
+	if (parseDNS.Query != "") && (!strings.HasSuffix(parseDNS.Query, "in-addr.arpa")) && (!strings.HasSuffix(parseDNS.Query, "ip6.arpa")) {
 		updateHostsByDNS(srcIP, srcUniqIP, srcKey, parseDNS, filter, retVals)
 	}
 }

--- a/parser/dns.go
+++ b/parser/dns.go
@@ -37,8 +37,8 @@ func parseDNSEntry(parseDNS *parsetypes.DNS, filter filter, retVals ParseResults
 
 	// in some of these strings, the empty space will get counted as a domain,
 	// don't add host or increment dns query count if queried domain
-	// is blank or ends in 'in-addr.arpa'
-	if (parseDNS.Query != "") && (!strings.HasSuffix(parseDNS.Query, "in-addr.arpa")) {
+	// is blank or ends in 'in-addr.arpa' or 'ip6.arpa'
+	if (parseDNS.Query != "") && (!strings.HasSuffix(parseDNS.Query, "in-addr.arpa")) && (!strings.HasSuffix(parseDNS.query, "ip6.arpa")) {
 		updateHostsByDNS(srcIP, srcUniqIP, srcKey, parseDNS, filter, retVals)
 	}
 }

--- a/pkg/explodeddns/analyzer.go
+++ b/pkg/explodeddns/analyzer.go
@@ -85,7 +85,7 @@ func (a *analyzer) start() {
 
 				// in some of these strings, the empty space will get counted as a domain,
 				// this was an issue in the old version of exploded dns and caused inaccuracies
-				if (entry == "") || (entry == "in-addr.arpa") {
+				if (entry == "") || (entry == "in-addr.arpa") || (entry == "ip6.arpa") {
 					break
 				}
 

--- a/pkg/hostname/analyzer.go
+++ b/pkg/hostname/analyzer.go
@@ -60,7 +60,7 @@ func (a *analyzer) start() {
 
 			// in some of these strings, the empty space will get counted as a domain,
 			// this was an issue in the old version of exploded dns and caused inaccuracies
-			if (data.Host == "") || (strings.HasSuffix(data.Host, "in-addr.arpa")) {
+			if (data.Host == "") || (strings.HasSuffix(data.Host, "in-addr.arpa")) || (strings.HasSuffix(data.Host, "ip6.arpa")) {
 				continue
 			}
 

--- a/pkg/remover/analyzer.go
+++ b/pkg/remover/analyzer.go
@@ -81,7 +81,7 @@ func (a *analyzer) reduceDNSSubCount(name string) {
 
 		// in some of these strings, the empty space will get counted as a domain,
 		// this was an issue in the old version of exploded dns and caused inaccuracies
-		if (entry == "") || (entry == "in-addr.arpa") {
+		if (entry == "") || (entry == "in-addr.arpa") || (entry == "ip6.arpa") {
 			break
 		}
 


### PR DESCRIPTION
Fixes #709 and excludes ip6.arpa requests similar to how in-addr.arpa requests are excluded.