### PR TITLE
Add Debian Install into install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -245,6 +245,21 @@ __install_zeek() {
         __install_packages zeek-lts
     fi
 
+     if  [ "$_OS" == "Debian" ] && [ "$_OS_CODENAME" == "buster" ] ; then
+        # The openSuse project hosts the Debian package for zeek. 
+        sudo apt-get install cmake make gcc g++ flex bison libpcap-dev libssl-dev python3 python3-dev python3-git python3-semantic-version
+        echo 'deb http://download.opensuse.org/repositories/security:/zeek/Debian_10/ /' | sudo tee /etc/apt/sources.list.d/security:zeek.list
+        curl -fsSL https://download.opensuse.org/repositories/security:zeek/Debian_10/Release.key | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/security_zeek.gpg > /dev/null
+        __freshen_packages
+        sudo apt install zeek
+    elif [ "$_OS" == "Debian" ] && [ "$_OS_CODENAME" == "bullseye" ] ; then
+        sudo apt-get install cmake make gcc g++ flex bison libpcap-dev libssl-dev python3 python3-dev python3-git python3-semantic-version
+        echo 'deb http://download.opensuse.org/repositories/security:/zeek/Debian_11/ /' | sudo tee /etc/apt/sources.list.d/security:zeek.list
+        curl -fsSL https://download.opensuse.org/repositories/security:zeek/Debian_11/Release.key | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/security_zeek.gpg > /dev/null
+        __freshen_packages
+        sudo apt install zeek
+    fi
+
 
     if [ -d /opt/zeek/logs/ ]; then		#Standard directory for Zeek logs when installed by Rita
         chmod 2755 /opt/zeek/logs
@@ -415,6 +430,12 @@ __install_mongodb() {
                 "mongodb-org-$1" \
                 "https://www.mongodb.org/static/pgp/server-$1.asc"
             ;;
+        Debian)
+            __add_deb_repo "deb [ arch=$(dpkg --print-architecture) ] http://repo.mongodb.org/apt/debian ${_MONGO_OS_CODENAME}/mongodb-org/$1 multiverse" \
+                "mongodb-org-$1" \
+                "https://www.mongodb.org/static/pgp/server-$1.asc"
+            ;;
+
         CentOS|RedHatEnterprise|RedHatEnterpriseServer)
             if [ ! -s /etc/yum.repos.d/mongodb-org-$1.repo ]; then
                 cat << EOF > /etc/yum.repos.d/mongodb-org-$1.repo
@@ -501,8 +522,8 @@ __gather_OS() {
     _OS_CODENAME="$(lsb_release -cs)"
     _MONGO_OS_CODENAME="$(lsb_release -cs)"
 
-    if [ "$_OS" != "Ubuntu" -a "$_OS" != "CentOS" -a "$_OS" != "RedHatEnterprise" -a "$_OS" != "RedHatEnterpriseServer" ]; then
-        printf "$_ITEM This installer supports Ubuntu, CentOS, and RHEL. \n"
+    if [ "$_OS" != "Ubuntu" -a "$_OS" != "CentOS" -a "$_OS" != "RedHatEnterprise" -a "$_OS" != "RedHatEnterpriseServer" -a "$_OS" != "Debian"]; then
+        printf "$_ITEM This installer supports Ubuntu, CentOS, RHEL, and Debian. \n"
         printf "$_IMPORTANT Your operating system is unsupported."
         exit 1
     fi

--- a/install.sh
+++ b/install.sh
@@ -124,6 +124,7 @@ __install() {
 
     # Get system information
     __gather_OS
+    __gather_debian_num
     __bro_installed
     __gather_zeek
     __gather_mongo
@@ -240,15 +241,9 @@ __install_zeek() {
                 ;;
             Debian)
                 __install_packages cmake make gcc g++ flex bison libpcap-dev libssl-dev python3 python3-dev python3-git python3-semantic-version curl gpg
-                if ["$_OS_CODENAME" == "buster"] ; then
-                    echo 'deb http://download.opensuse.org/repositories/security:/zeek/Debian_10/ /' | sudo tee /etc/apt/sources.list.d/security:zeek.list
-                    curl -fsSL https://download.opensuse.org/repositories/security:zeek/Debian_10/Release.key | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/security_zeek.gpg > /dev/null
-                    __freshen_packages
-                else
-                   echo 'deb http://download.opensuse.org/repositories/security:/zeek/Debian_11/ /' | sudo tee /etc/apt/sources.list.d/security:zeek.list
-                   curl -fsSL https://download.opensuse.org/repositories/security:zeek/Debian_11/Release.key | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/security_zeek.gpg > /dev/null
-                   __freshen_packages
-                fi
+                echo 'deb http://download.opensuse.org/repositories/security:/zeek/$(_Debian_Release)//' | sudo tee /etc/apt/sources.list.d/security:zeek.list
+                curl -fsSL https://download.opensuse.org/repositories/security:zeek/Debian_10/Release.key | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/security_zeek.gpg > /dev/null
+                __freshen_packages
                 ;;
             CentOS|RedHatEnterprise|RedHatEnterpriseServer)
                 __add_rpm_repo "https://download.opensuse.org/repositories/security:/zeek/CentOS_7/security:zeek.repo"
@@ -523,6 +518,17 @@ __gather_OS() {
         printf "$_ITEM This installer supports Ubuntu, CentOS, RHEL, and Debian. \n"
         printf "$_IMPORTANT Your operating system is unsupported."
         exit 1
+    fi
+}
+
+# Test if Debian Version 10 or 11
+__gather_debian_num() {
+    if [[ "$_OS" -eq "buster" ]]; then
+        _Debian_Release="Debian_10"
+    elif [[ "$_OS" -eq "bullseye" ]]; then
+        _Debian_Release="Debian_11"
+    else
+        _Debian_Release=''
     fi
 }
 

--- a/install.sh
+++ b/install.sh
@@ -5,7 +5,7 @@
 
 # CONSTANTS
 _RITA_VERSION="v4.5.0"
-_MONGO_VERSION=$(__set_mongo_version)
+__set_mongo_version
 printf "\nMongo Version: $_MONGO_VERSION"
 _MONGO_MIN_UPDATE_VERSION="5.0"
 _NAME=$(basename "${0}")
@@ -632,9 +632,9 @@ __gather_mongo() {
 
 __set_mongo_version() {
     if [[ "$_OS" == "Debian" ]]; then
-        echo "5.0"
+        _MONGO_VERSION="5.0"
     else
-        echo " 4.2"
+        _MONGO_VERSION="4.2"
     fi
 }
 

--- a/install.sh
+++ b/install.sh
@@ -156,7 +156,7 @@ __install() {
 
     if [ "$_INSTALL_MONGO" = "true" ]; then
         if [ "$_MONGO_INSTALLED" = "false" ]; then
-            __load "$_ITEM Installing MongoDB" __install_mongodb "$_MONGO_VERSION" 
+            __load "$_ITEM Installing MongoDB" __install_mongodb "$_MONGO_VERSION"
         elif ! __satisfies_version "$_MONGO_INSTALLED_VERSION" "$_MONGO_VERSION" ; then
 
             # Check that the user wants to upgrade
@@ -424,6 +424,7 @@ __install_mongodb() {
                 "https://www.mongodb.org/static/pgp/server-$1.asc"
             ;;
         Debian)
+        # Mongodb does not have a release file for Debian 11 "Bullseye" yet.
             __add_deb_repo "deb http://repo.mongodb.org/apt/debian buster/mongodb-org/$1 main" \
                 "mongodb-org-$1" \
                 "https://www.mongodb.org/static/pgp/server-$1.asc"

--- a/install.sh
+++ b/install.sh
@@ -5,8 +5,6 @@
 
 # CONSTANTS
 _RITA_VERSION="v4.5.0"
-__set_mongo_version
-printf "\nMongo Version: $_MONGO_VERSION"
 _MONGO_MIN_UPDATE_VERSION="5.0"
 _NAME=$(basename "${0}")
 _FAILED="\e[91mFAILED\e[0m"
@@ -624,6 +622,8 @@ __gather_zeek() {
 
 __gather_mongo() {
     _MONGO_INSTALLED=false
+    __set_mongo_version
+    printf "\nMongo Version: $_MONGO_VERSION"
     if __package_installed mongodb-org; then
         _MONGO_INSTALLED=true
         _MONGO_INSTALLED_VERSION="$(__package_version mongodb-org)"

--- a/install.sh
+++ b/install.sh
@@ -242,7 +242,7 @@ __install_zeek() {
             Debian)
                 __install_packages cmake make gcc g++ flex bison libpcap-dev libssl-dev python3 python3-dev python3-git python3-semantic-version swig zlib1g-dev gpg
                 __add_deb_repo  "deb http://download.opensuse.org/repositories/security:/zeek/$_Debian_Release/ /" \
-                "security:zeek.list" \
+                "security:zeek" \
                 "https://download.opensuse.org/repositories/security:zeek/$_Debian_Release/Release.key"
                 __freshen_packages
                 ;;
@@ -524,12 +524,12 @@ __gather_OS() {
 
 # Test if Debian Version 10 or 11
 __gather_debian_num() {
-    if [[ "$_OS" -eq "buster" ]]; then
-        _Debian_Release="Debian_10"
-    elif [[ "$_OS" -eq "bullseye" ]]; then
+    if [[ "$_OS_CODENAME" -eq "buster" ]]; then
+        _Debian_Release="Debian_11"
+    elif [[ "$_OS_CODENAME" -eq "bullseye" ]]; then
         _Debian_Release="Debian_11"
     else
-        _Debian_Release=''
+        _Debian_Release=""
     fi
 }
 

--- a/install.sh
+++ b/install.sh
@@ -624,18 +624,12 @@ __gather_zeek() {
 
 __gather_mongo() {
     _MONGO_INSTALLED=false
-    __set_mongo_version
     if __package_installed mongodb-org; then
         _MONGO_INSTALLED=true
         _MONGO_INSTALLED_VERSION="$(__package_version mongodb-org)"
     fi
 }
 
-__set_mongo_version() {
-    if [[ "$_OS" == "Debian" ]]; then
-        _MONGO_VERSION="4.4"
-    fi
-}
 
 # USER EXPERIENCE
 

--- a/install.sh
+++ b/install.sh
@@ -240,8 +240,8 @@ __install_zeek() {
                 "https://download.opensuse.org/repositories/security:/zeek/xUbuntu_$(lsb_release -rs)/Release.key"
                 ;;
             Debian)
-                __install_packages cmake make gcc g++ flex bison libpcap-dev libssl-dev python3 python3-dev python3-git python3-semantic-version curl gpg
-                echo 'deb http://download.opensuse.org/repositories/security:/zeek/$(_Debian_Release)//' | sudo tee /etc/apt/sources.list.d/security:zeek.list
+                __install_packages cmake make gcc g++ flex bison libpcap-dev libssl-dev python3 python3-dev python3-git python3-semantic-version swig zlib1g-dev gpg
+                echo "deb http://download.opensuse.org/repositories/security:/zeek/$_Debian_Release/ /" | sudo tee /etc/apt/sources.list.d/security:zeek.list
                 curl -fsSL https://download.opensuse.org/repositories/security:zeek/Debian_10/Release.key | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/security_zeek.gpg > /dev/null
                 __freshen_packages
                 ;;

--- a/install.sh
+++ b/install.sh
@@ -5,7 +5,7 @@
 
 # CONSTANTS
 _RITA_VERSION="v4.5.0"
-_MONGO_MIN_UPDATE_VERSION="5.0"
+_MONGO_MIN_UPDATE_VERSION="4.2"
 _NAME=$(basename "${0}")
 _FAILED="\e[91mFAILED\e[0m"
 _SUCCESS="\e[92mSUCCESS\e[0m"
@@ -423,7 +423,7 @@ __install_mongodb() {
                 "https://www.mongodb.org/static/pgp/server-$1.asc"
             ;;
         Debian)
-            __add_deb_repo "deb  http://repo.mongodb.org/apt/debian buster/mongodb-org/$1 main" \
+            __add_deb_repo "deb  [ arch=$(dpkg --print-architecture) ] http://repo.mongodb.org/apt/debian buster/mongodb-org/$1 main" \
                 "mongodb-org-$1" \
                 "https://www.mongodb.org/static/pgp/server-$1.asc"
             ;;
@@ -524,7 +524,7 @@ __gather_OS() {
 # Test if Debian Version 10 or 11
 __gather_debian_num() {
     if [[ "$_OS_CODENAME" == "buster" ]]; then
-        _Debian_Release="Debian_11"
+        _Debian_Release="Debian_10"
     elif [[ "$_OS_CODENAME" == "bullseye" ]]; then
         _Debian_Release="Debian_11"
     else

--- a/install.sh
+++ b/install.sh
@@ -241,8 +241,9 @@ __install_zeek() {
                 ;;
             Debian)
                 __install_packages cmake make gcc g++ flex bison libpcap-dev libssl-dev python3 python3-dev python3-git python3-semantic-version swig zlib1g-dev gpg
-                echo "deb http://download.opensuse.org/repositories/security:/zeek/$_Debian_Release/ /" | sudo tee /etc/apt/sources.list.d/security:zeek.list
-                curl -fsSL https://download.opensuse.org/repositories/security:zeek/Debian_10/Release.key | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/security_zeek.gpg > /dev/null
+                __add_deb_repo  "deb http://download.opensuse.org/repositories/security:/zeek/$_Debian_Release/ /" \
+                "security:zeek.list" \
+                "https://download.opensuse.org/repositories/security:zeek/$_Debian_Release/Release.key"
                 __freshen_packages
                 ;;
             CentOS|RedHatEnterprise|RedHatEnterpriseServer)

--- a/install.sh
+++ b/install.sh
@@ -5,8 +5,8 @@
 
 # CONSTANTS
 _RITA_VERSION="v4.5.0"
-_MONGO_VERSION="4.2"
-_MONGO_MIN_UPDATE_VERSION="4.0"
+_MONGO_VERSION="5.0"
+_MONGO_MIN_UPDATE_VERSION="5.0"
 _NAME=$(basename "${0}")
 _FAILED="\e[91mFAILED\e[0m"
 _SUCCESS="\e[92mSUCCESS\e[0m"
@@ -424,9 +424,9 @@ __install_mongodb() {
                 "https://www.mongodb.org/static/pgp/server-$1.asc"
             ;;
         Debian)
-            __add_deb_repo "deb [ arch=$(dpkg --print-architecture) ] http://repo.mongodb.org/apt/debian buster/mongodb-org/$1 multiverse" \
-                "mongodb-org-$1" \
-                "https://www.mongodb.org/static/pgp/server-$1.asc"
+            __add_deb_repo "deb [ arch=$(dpkg --print-architecture) ] http://repo.mongodb.org/apt/debian buster/mongodb-org/5.0 main" \
+                "mongodb-org-5.0" \
+                "https://www.mongodb.org/static/pgp/server-5.0.asc"
             ;;
 
         CentOS|RedHatEnterprise|RedHatEnterpriseServer)
@@ -524,9 +524,9 @@ __gather_OS() {
 
 # Test if Debian Version 10 or 11
 __gather_debian_num() {
-    if [[ "$_OS_CODENAME" -eq "buster" ]]; then
+    if [[ "$_OS_CODENAME" == "buster" ]]; then
         _Debian_Release="Debian_11"
-    elif [[ "$_OS_CODENAME" -eq "bullseye" ]]; then
+    elif [[ "$_OS_CODENAME" == "bullseye" ]]; then
         _Debian_Release="Debian_11"
     else
         _Debian_Release=""

--- a/install.sh
+++ b/install.sh
@@ -238,26 +238,23 @@ __install_zeek() {
                 "security:zeek" \
                 "https://download.opensuse.org/repositories/security:/zeek/xUbuntu_$(lsb_release -rs)/Release.key"
                 ;;
+            Debian)
+                __install_packages cmake make gcc g++ flex bison libpcap-dev libssl-dev python3 python3-dev python3-git python3-semantic-version curl gpg
+                if ["$_OS_CODENAME" == "buster"] ; then
+                    echo 'deb http://download.opensuse.org/repositories/security:/zeek/Debian_10/ /' | sudo tee /etc/apt/sources.list.d/security:zeek.list
+                    curl -fsSL https://download.opensuse.org/repositories/security:zeek/Debian_10/Release.key | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/security_zeek.gpg > /dev/null
+                    __freshen_packages
+                else
+                   echo 'deb http://download.opensuse.org/repositories/security:/zeek/Debian_11/ /' | sudo tee /etc/apt/sources.list.d/security:zeek.list
+                   curl -fsSL https://download.opensuse.org/repositories/security:zeek/Debian_11/Release.key | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/security_zeek.gpg > /dev/null
+                   __freshen_packages
+                fi
+                ;;
             CentOS|RedHatEnterprise|RedHatEnterpriseServer)
                 __add_rpm_repo "https://download.opensuse.org/repositories/security:/zeek/CentOS_7/security:zeek.repo"
                 ;;
         esac
         __install_packages zeek-lts
-    fi
-
-     if  [ "$_OS" == "Debian" ] && [ "$_OS_CODENAME" == "buster" ] ; then
-        # The openSuse project hosts the Debian package for zeek. 
-        sudo apt-get install cmake make gcc g++ flex bison libpcap-dev libssl-dev python3 python3-dev python3-git python3-semantic-version
-        echo 'deb http://download.opensuse.org/repositories/security:/zeek/Debian_10/ /' | sudo tee /etc/apt/sources.list.d/security:zeek.list
-        curl -fsSL https://download.opensuse.org/repositories/security:zeek/Debian_10/Release.key | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/security_zeek.gpg > /dev/null
-        __freshen_packages
-        sudo apt install zeek
-    elif [ "$_OS" == "Debian" ] && [ "$_OS_CODENAME" == "bullseye" ] ; then
-        sudo apt-get install cmake make gcc g++ flex bison libpcap-dev libssl-dev python3 python3-dev python3-git python3-semantic-version
-        echo 'deb http://download.opensuse.org/repositories/security:/zeek/Debian_11/ /' | sudo tee /etc/apt/sources.list.d/security:zeek.list
-        curl -fsSL https://download.opensuse.org/repositories/security:zeek/Debian_11/Release.key | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/security_zeek.gpg > /dev/null
-        __freshen_packages
-        sudo apt install zeek
     fi
 
 
@@ -522,7 +519,7 @@ __gather_OS() {
     _OS_CODENAME="$(lsb_release -cs)"
     _MONGO_OS_CODENAME="$(lsb_release -cs)"
 
-    if [ "$_OS" != "Ubuntu" -a "$_OS" != "CentOS" -a "$_OS" != "RedHatEnterprise" -a "$_OS" != "RedHatEnterpriseServer" -a "$_OS" != "Debian"]; then
+    if [ "$_OS" != "Ubuntu" -a "$_OS" != "CentOS" -a "$_OS" != "RedHatEnterprise" -a "$_OS" != "RedHatEnterpriseServer" -a "$_OS" != "Debian" ]; then
         printf "$_ITEM This installer supports Ubuntu, CentOS, RHEL, and Debian. \n"
         printf "$_IMPORTANT Your operating system is unsupported."
         exit 1

--- a/install.sh
+++ b/install.sh
@@ -5,7 +5,8 @@
 
 # CONSTANTS
 _RITA_VERSION="v4.5.0"
-_MONGO_MIN_UPDATE_VERSION="4.2"
+_MONGO_VERSION="4.2"
+_MONGO_MIN_UPDATE_VERSION="4.0"
 _NAME=$(basename "${0}")
 _FAILED="\e[91mFAILED\e[0m"
 _SUCCESS="\e[92mSUCCESS\e[0m"
@@ -186,7 +187,7 @@ __install() {
             # Wait for service to come to life
             printf "$_ITEM Sleeping to give the Mongo service some time to fully start..."
             sleep 10
-             
+
             # Set compatibility version in case we updated Mongo. It's fine to do this even if we didn't
             # update Mongo...it's just a bit cleaner to do it here to cut down on code redundancy and logic checks
             __load "$_ITEM Setting Mongo feature compatibility to $_MONGO_VERSION" __update_feature_compatibility "$_MONGO_VERSION"
@@ -423,7 +424,7 @@ __install_mongodb() {
                 "https://www.mongodb.org/static/pgp/server-$1.asc"
             ;;
         Debian)
-            __add_deb_repo "deb  [ arch=$(dpkg --print-architecture) ] http://repo.mongodb.org/apt/debian buster/mongodb-org/$1 main" \
+            __add_deb_repo "deb http://repo.mongodb.org/apt/debian buster/mongodb-org/$1 main" \
                 "mongodb-org-$1" \
                 "https://www.mongodb.org/static/pgp/server-$1.asc"
             ;;
@@ -631,13 +632,9 @@ __gather_mongo() {
 
 __set_mongo_version() {
     if [[ "$_OS" == "Debian" ]]; then
-        _MONGO_VERSION="5.0"
-    else
-        _MONGO_VERSION="4.2"
+        _MONGO_VERSION="4.4"
     fi
 }
-
-
 
 # USER EXPERIENCE
 

--- a/install.sh
+++ b/install.sh
@@ -449,7 +449,7 @@ EOF
 
 __configure_mongodb() {
     printf "$_IMPORTANT Starting MongoDB and enabling on startup. \n"
-    if [ "$_OS" = "Ubuntu" || "$_OS" = "Debian" ]; then
+    if [ "$_OS" = "Ubuntu" -o "$_OS" = "Debian" ]; then
         systemctl enable mongod.service > /dev/null
         systemctl daemon-reload > /dev/null
         systemctl start mongod > /dev/null

--- a/install.sh
+++ b/install.sh
@@ -423,9 +423,9 @@ __install_mongodb() {
                 "https://www.mongodb.org/static/pgp/server-$1.asc"
             ;;
         Debian)
-            __add_deb_repo "deb [ arch=$(dpkg --print-architecture) ] http://repo.mongodb.org/apt/debian buster/mongodb-org/5.0 main" \
-                "mongodb-org-5.0" \
-                "https://www.mongodb.org/static/pgp/server-5.0.asc"
+            __add_deb_repo "deb  http://repo.mongodb.org/apt/debian buster/mongodb-org/$1 main" \
+                "mongodb-org-$1" \
+                "https://www.mongodb.org/static/pgp/server-$1.asc"
             ;;
 
         CentOS|RedHatEnterprise|RedHatEnterpriseServer)
@@ -623,7 +623,6 @@ __gather_zeek() {
 __gather_mongo() {
     _MONGO_INSTALLED=false
     __set_mongo_version
-    printf "\nMongo Version: $_MONGO_VERSION"
     if __package_installed mongodb-org; then
         _MONGO_INSTALLED=true
         _MONGO_INSTALLED_VERSION="$(__package_version mongodb-org)"

--- a/install.sh
+++ b/install.sh
@@ -424,7 +424,7 @@ __install_mongodb() {
                 "https://www.mongodb.org/static/pgp/server-$1.asc"
             ;;
         Debian)
-            __add_deb_repo "deb [ arch=$(dpkg --print-architecture) ] http://repo.mongodb.org/apt/debian ${_MONGO_OS_CODENAME}/mongodb-org/$1 multiverse" \
+            __add_deb_repo "deb [ arch=$(dpkg --print-architecture) ] http://repo.mongodb.org/apt/debian buster/mongodb-org/$1 multiverse" \
                 "mongodb-org-$1" \
                 "https://www.mongodb.org/static/pgp/server-$1.asc"
             ;;
@@ -450,7 +450,7 @@ EOF
 
 __configure_mongodb() {
     printf "$_IMPORTANT Starting MongoDB and enabling on startup. \n"
-    if [ "$_OS" = "Ubuntu" ]; then
+    if [ "$_OS" = "Ubuntu" || "$_OS" = "Debian" ]; then
         systemctl enable mongod.service > /dev/null
         systemctl daemon-reload > /dev/null
         systemctl start mongod > /dev/null

--- a/install.sh
+++ b/install.sh
@@ -5,7 +5,8 @@
 
 # CONSTANTS
 _RITA_VERSION="v4.5.0"
-_MONGO_VERSION="5.0"
+_MONGO_VERSION=$(__set_mongo_version)
+printf "\nMongo Version: $_MONGO_VERSION"
 _MONGO_MIN_UPDATE_VERSION="5.0"
 _NAME=$(basename "${0}")
 _FAILED="\e[91mFAILED\e[0m"
@@ -628,6 +629,16 @@ __gather_mongo() {
         _MONGO_INSTALLED_VERSION="$(__package_version mongodb-org)"
     fi
 }
+
+__set_mongo_version() {
+    if [[ "$_OS" == "Debian" ]]; then
+        echo "5.0"
+    else
+        echo " 4.2"
+    fi
+}
+
+
 
 # USER EXPERIENCE
 


### PR DESCRIPTION
Install script modified to install Rita on Debian 10 and 11. 
The Zeek Binary comes from The Opensuse Project. This is a trusted source and the install has been tested.
Mongodb does not yet have a release for Debian 11 yet. This install has been tested on Debian 11 with no issues. 
Tested on clean installs of updated Debian 10/11 virtual machines with no issues to note. 