### PR TITLE
Support Ubuntu 20.04 LTS

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -21,7 +21,7 @@ Please see our recommended [System Requirements](docs/System%20Requirements.md) 
 
 ### Automated Install
 
-RITA provides an install script that works on Ubuntu 18.04 LTS, Ubuntu 16.04 LTS, Debian 10, Debian 11, Security Onion, and CentOS 7.
+RITA provides an install script that works on Ubuntu 20.04 LTS, Ubuntu 18.04 LTS, Ubuntu 16.04 LTS, Debian 10, Debian 11, Security Onion, and CentOS 7.
 
 Download the latest `install.sh` file [here](https://github.com/activecm/rita/releases/latest) and make it executable: `chmod +x ./install.sh`
 

--- a/install.sh
+++ b/install.sh
@@ -521,6 +521,11 @@ __gather_OS() {
     _OS_CODENAME="$(lsb_release -cs)"
     _MONGO_OS_CODENAME="$(lsb_release -cs)"
 
+    # Use the Ubuntu 18 package for MongoDB 4.2 on Xenial
+    if [ "$_OS" = "Ubuntu" -a "$_MONGO_OS_CODENAME" = "focal" ]; then 
+        _MONGO_OS_CODENAME = "bionic"
+    fi
+
     if [ "$_OS" != "Ubuntu" -a "$_OS" != "CentOS" -a "$_OS" != "RedHatEnterprise" -a "$_OS" != "RedHatEnterpriseServer" -a "$_OS" != "Debian" ]; then
         printf "$_ITEM This installer supports Ubuntu, CentOS, RHEL, and Debian. \n"
         printf "$_IMPORTANT Your operating system is unsupported."


### PR DESCRIPTION
Following the discussion in #587, this PR instructs the installer to use the Ubuntu 18 MongoDB 4.2 package when installing on Ubuntu 20. I have tested this out on Ubuntu 20 and was able to successfully install RITA.