### PR TITLE
Patch to fix uconn timestamp storage 

### DIFF
--- a/parser/conn.go
+++ b/parser/conn.go
@@ -124,7 +124,7 @@ func updateUniqueConnectionsByConn(srcIP, dstIP net.IP, srcDstPair data.UniqueIP
 	// ///// INCREMENT THE CONNECTION COUNT FOR THE UNIQUE CONNECTION /////
 	retVals.UniqueConnMap[srcDstKey].ConnectionCount++
 
-	// ///// UNION TIMESTAMP WITH UNIQUE CONNECTION TIMESTAMP SET /////
+	// ///// APPEND TIMESTAMP TO UNIQUE CONNECTION TIMESTAMP LIST /////
 	retVals.UniqueConnMap[srcDstKey].TsList = append(
 		retVals.UniqueConnMap[srcDstKey].TsList, parseConn.TimeStamp,
 	)

--- a/parser/conn.go
+++ b/parser/conn.go
@@ -125,11 +125,9 @@ func updateUniqueConnectionsByConn(srcIP, dstIP net.IP, srcDstPair data.UniqueIP
 	retVals.UniqueConnMap[srcDstKey].ConnectionCount++
 
 	// ///// UNION TIMESTAMP WITH UNIQUE CONNECTION TIMESTAMP SET /////
-	if !util.Int64InSlice(parseConn.TimeStamp, retVals.UniqueConnMap[srcDstKey].TsList) {
-		retVals.UniqueConnMap[srcDstKey].TsList = append(
-			retVals.UniqueConnMap[srcDstKey].TsList, parseConn.TimeStamp,
-		)
-	}
+	retVals.UniqueConnMap[srcDstKey].TsList = append(
+		retVals.UniqueConnMap[srcDstKey].TsList, parseConn.TimeStamp,
+	)
 
 	// ///// APPEND IP BYTES TO UNIQUE CONNECTION BYTES LIST /////
 	retVals.UniqueConnMap[srcDstKey].OrigBytesList = append(

--- a/parser/ssl.go
+++ b/parser/ssl.go
@@ -99,10 +99,9 @@ func updateTLSConnectionsBySSL(srcIP net.IP, dstUniqIP data.UniqueIP, srcFQDNPai
 
 	if _, ok := retVals.TLSConnMap[srcFQDNKey]; !ok {
 		retVals.TLSConnMap[srcFQDNKey] = &sniconn.TLSInput{
-			Hosts:      srcFQDNPair,
-			IsLocalSrc: filter.checkIfInternal(srcIP),
-
-			Timestamps:      make(data.Int64Set),
+			Hosts:           srcFQDNPair,
+			IsLocalSrc:      filter.checkIfInternal(srcIP),
+			Timestamps:      []int64{},
 			RespondingIPs:   make(data.UniqueIPSet),
 			RespondingPorts: make(data.IntSet),
 

--- a/parser/ssl.go
+++ b/parser/ssl.go
@@ -115,8 +115,10 @@ func updateTLSConnectionsBySSL(srcIP net.IP, dstUniqIP data.UniqueIP, srcFQDNPai
 	// ///// INCREMENT THE CONNECTION COUNT FOR THE TLS SNI CONNECTION /////
 	retVals.TLSConnMap[srcFQDNKey].ConnectionCount++
 
-	// ///// UNION TIMESTAMP INTO TLS TIMESTAMP SET /////
-	retVals.TLSConnMap[srcFQDNKey].Timestamps.Insert(parseSSL.TimeStamp)
+	// ///// APPEND TIMESTAMP TO TLS TIMESTAMP LIST /////
+	retVals.TLSConnMap[srcFQDNKey].Timestamps = append(
+		retVals.TLSConnMap[srcFQDNKey].Timestamps, parseSSL.TimeStamp,
+	)
 
 	// ///// UNION DESTINATION HOST INTO TLS RESPONDING HOSTS /////
 	retVals.TLSConnMap[srcFQDNKey].RespondingIPs.Insert(dstUniqIP)

--- a/pkg/beacon/analyzer.go
+++ b/pkg/beacon/analyzer.go
@@ -102,6 +102,16 @@ func (a *analyzer) start() {
 					diff[i] = res.TsList[i+1] - res.TsList[i]
 				}
 
+				//find the delta times between full list of timestamps
+				//(this will be used for the intervals list. Bowleys skew
+				//must use a unique timestamp list with no duplicates)
+				tsLengthFull := len(res.TsListFull) - 1
+				//find the delta times between the timestamps
+				diffFull := make([]int64, tsLengthFull)
+				for i := 0; i < tsLengthFull; i++ {
+					diffFull[i] = res.TsListFull[i+1] - res.TsListFull[i]
+				}
+
 				//perfect beacons should have symmetric delta time and size distributions
 				//Bowley's measure of skew is used to check symmetry
 				sort.Sort(util.SortableInt64(diff))
@@ -159,7 +169,9 @@ func (a *analyzer) start() {
 				//get a list of the intervals found in the data,
 				//the number of times the interval was found,
 				//and the most occurring interval
-				intervals, intervalCounts, tsMode, tsModeCount := createCountMap(diff)
+				//sort intervals list (origbytes already sorted)
+				sort.Sort(util.SortableInt64(diffFull))
+				intervals, intervalCounts, tsMode, tsModeCount := createCountMap(diffFull)
 				dsSizes, dsCounts, dsMode, dsModeCount := createCountMap(res.OrigBytesList)
 
 				//more skewed distributions receive a lower score

--- a/pkg/beacon/dissector.go
+++ b/pkg/beacon/dissector.go
@@ -104,33 +104,37 @@ func (d *dissector) start() {
 				{"$unwind": "$ts"},
 				{"$unwind": "$ts"},
 				{"$group": bson.M{
-					"_id":    "$_id",
-					"ts":     bson.M{"$addToSet": "$ts"},
-					"bytes":  bson.M{"$first": "$bytes"},
-					"count":  bson.M{"$first": "$count"},
-					"tbytes": bson.M{"$first": "$tbytes"},
+					"_id":     "$_id",
+					"ts":      bson.M{"$addToSet": "$ts"},
+					"ts_full": bson.M{"$push": "$ts"},
+					"bytes":   bson.M{"$first": "$bytes"},
+					"count":   bson.M{"$first": "$count"},
+					"tbytes":  bson.M{"$first": "$tbytes"},
 				}},
 				{"$unwind": "$bytes"},
 				{"$unwind": "$bytes"},
 				{"$group": bson.M{
-					"_id":    "$_id",
-					"ts":     bson.M{"$first": "$ts"},
-					"bytes":  bson.M{"$push": "$bytes"},
-					"count":  bson.M{"$first": "$count"},
-					"tbytes": bson.M{"$first": "$tbytes"},
+					"_id":     "$_id",
+					"ts":      bson.M{"$first": "$ts"},
+					"ts_full": bson.M{"$first": "$ts_full"},
+					"bytes":   bson.M{"$push": "$bytes"},
+					"count":   bson.M{"$first": "$count"},
+					"tbytes":  bson.M{"$first": "$tbytes"},
 				}},
 				{"$project": bson.M{
-					"_id":    "$_id",
-					"ts":     1,
-					"bytes":  1,
-					"count":  1,
-					"tbytes": 1,
+					"_id":     "$_id",
+					"ts":      1,
+					"ts_full": 1,
+					"bytes":   1,
+					"count":   1,
+					"tbytes":  1,
 				}},
 			}
 
 			var res struct {
 				Count  int64   `bson:"count"`
 				Ts     []int64 `bson:"ts"`
+				TsFull []int64 `bson:"ts_full"`
 				Bytes  []int64 `bson:"bytes"`
 				TBytes int64   `bson:"tbytes"`
 			}
@@ -152,6 +156,7 @@ func (d *dissector) start() {
 
 				} else { // otherwise, parse timestamps and orig ip bytes
 					analysisInput.TsList = res.Ts
+					analysisInput.TsListFull = res.TsFull
 					analysisInput.OrigBytesList = res.Bytes
 					// the analysis worker requires that we have over UNIQUE 3 timestamps
 					// we drop the input here since it is the earliest place in the pipeline to do so

--- a/pkg/beacon/sorter.go
+++ b/pkg/beacon/sorter.go
@@ -57,6 +57,7 @@ func (s *sorter) start() {
 			if (data.TsList) != nil {
 				//sort the size and timestamps to compute quantiles in the analyzer
 				sort.Sort(util.SortableInt64(data.TsList))
+				sort.Sort(util.SortableInt64(data.TsListFull))
 				sort.Sort(util.SortableInt64(data.OrigBytesList))
 			}
 			s.sortedCallback(data)

--- a/pkg/beaconfqdn/analyzer.go
+++ b/pkg/beaconfqdn/analyzer.go
@@ -115,6 +115,16 @@ func (a *analyzer) start() {
 					diff[i] = entry.TsList[i+1] - entry.TsList[i]
 				}
 
+				//find the delta times between full list of timestamps
+				//(this will be used for the intervals list. Bowleys skew
+				//must use a unique timestamp list with no duplicates)
+				tsLengthFull := len(entry.TsListFull) - 1
+				//find the delta times between the timestamps
+				diffFull := make([]int64, tsLengthFull)
+				for i := 0; i < tsLengthFull; i++ {
+					diffFull[i] = entry.TsListFull[i+1] - entry.TsListFull[i]
+				}
+
 				//perfect beacons should have symmetric delta time and size distributions
 				//Bowley's measure of skew is used to check symmetry
 				sort.Sort(util.SortableInt64(diff))
@@ -172,7 +182,9 @@ func (a *analyzer) start() {
 				//get a list of the intervals found in the data,
 				//the number of times the interval was found,
 				//and the most occurring interval
-				intervals, intervalCounts, tsMode, tsModeCount := createCountMap(diff)
+				//sort intervals list (origbytes already sorted)
+				sort.Sort(util.SortableInt64(diffFull))
+				intervals, intervalCounts, tsMode, tsModeCount := createCountMap(diffFull)
 				dsSizes, dsCounts, dsMode, dsModeCount := createCountMap(entry.OrigBytesList)
 
 				//more skewed distributions receive a lower score

--- a/pkg/beaconfqdn/repository.go
+++ b/pkg/beaconfqdn/repository.go
@@ -35,6 +35,7 @@ type (
 		ConnectionCount int64
 		TotalBytes      int64
 		TsList          []int64
+		TsListFull      []int64
 		OrigBytesList   []int64
 		DstBSONList     []bson.M // set of resolved UniqueDstIPs since we need it in that format
 	}

--- a/pkg/beaconfqdn/sorter.go
+++ b/pkg/beaconfqdn/sorter.go
@@ -56,6 +56,7 @@ func (s *sorter) start() {
 			if (entry.TsList) != nil {
 				//sort the size and timestamps to compute quantiles in the analyzer
 				sort.Sort(util.SortableInt64(entry.TsList))
+				sort.Sort(util.SortableInt64(entry.TsListFull))
 				sort.Sort(util.SortableInt64(entry.OrigBytesList))
 			}
 			s.sortedCallback(entry)

--- a/pkg/beaconproxy/analyzer.go
+++ b/pkg/beaconproxy/analyzer.go
@@ -101,6 +101,16 @@ func (a *analyzer) start() {
 					diff[i] = entry.TsList[i+1] - entry.TsList[i]
 				}
 
+				//find the delta times between full list of timestamps
+				//(this will be used for the intervals list. Bowleys skew
+				//must use a unique timestamp list with no duplicates)
+				tsLengthFull := len(entry.TsListFull) - 1
+				//find the delta times between the timestamps
+				diffFull := make([]int64, tsLengthFull)
+				for i := 0; i < tsLengthFull; i++ {
+					diffFull[i] = entry.TsListFull[i+1] - entry.TsListFull[i]
+				}
+
 				//perfect beacons should have symmetric delta time and size distributions
 				//Bowley's measure of skew is used to check symmetry
 				sort.Sort(util.SortableInt64(diff))
@@ -138,7 +148,9 @@ func (a *analyzer) start() {
 				//get a list of the intervals found in the data,
 				//the number of times the interval was found,
 				//and the most occurring interval
-				intervals, intervalCounts, tsMode, tsModeCount := createCountMap(diff)
+				//sort intervals list
+				sort.Sort(util.SortableInt64(diffFull))
+				intervals, intervalCounts, tsMode, tsModeCount := createCountMap(diffFull)
 
 				//more skewed distributions receive a lower score
 				//less skewed distributions receive a higher score

--- a/pkg/beaconproxy/sorter.go
+++ b/pkg/beaconproxy/sorter.go
@@ -52,8 +52,9 @@ func (s *sorter) start() {
 		for entry := range s.sortChannel {
 
 			if (entry.TsList) != nil {
-				//sort the size and timestamps to compute quantiles in the analyzer
+				//sort the timestamp lists to compute quantiles in the analyzer
 				sort.Sort(util.SortableInt64(entry.TsList))
+				sort.Sort(util.SortableInt64(entry.TsListFull))
 			}
 
 			s.sortedCallback(entry)

--- a/pkg/beaconsni/analyzer.go
+++ b/pkg/beaconsni/analyzer.go
@@ -106,6 +106,16 @@ func (a *analyzer) start() {
 					diff[i] = res.TsList[i+1] - res.TsList[i]
 				}
 
+				//find the delta times between full list of timestamps
+				//(this will be used for the intervals list. Bowleys skew
+				//must use a unique timestamp list with no duplicates)
+				tsLengthFull := len(res.TsListFull) - 1
+				//find the delta times between the timestamps
+				diffFull := make([]int64, tsLengthFull)
+				for i := 0; i < tsLengthFull; i++ {
+					diffFull[i] = res.TsListFull[i+1] - res.TsListFull[i]
+				}
+
 				//perfect beacons should have symmetric delta time and size distributions
 				//Bowley's measure of skew is used to check symmetry
 				sort.Sort(util.SortableInt64(diff))
@@ -163,7 +173,9 @@ func (a *analyzer) start() {
 				//get a list of the intervals found in the data,
 				//the number of times the interval was found,
 				//and the most occurring interval
-				intervals, intervalCounts, tsMode, tsModeCount := createCountMap(diff)
+				//sort intervals list (origbytes already sorted)
+				sort.Sort(util.SortableInt64(diffFull))
+				intervals, intervalCounts, tsMode, tsModeCount := createCountMap(diffFull)
 				dsSizes, dsCounts, dsMode, dsModeCount := createCountMap(res.OrigBytesList)
 
 				//more skewed distributions receive a lower score

--- a/pkg/beaconsni/repository.go
+++ b/pkg/beaconsni/repository.go
@@ -23,6 +23,7 @@ type dissectorResults struct {
 	ConnectionCount int64
 	TotalBytes      int64
 	TsList          []int64
+	TsListFull      []int64
 	OrigBytesList   []int64
 }
 

--- a/pkg/beaconsni/sorter.go
+++ b/pkg/beaconsni/sorter.go
@@ -56,6 +56,7 @@ func (s *sorter) start() {
 			if (data.TsList) != nil {
 				//sort the size and timestamps to compute quantiles in the analyzer
 				sort.Sort(util.SortableInt64(data.TsList))
+				sort.Sort(util.SortableInt64(data.TsListFull))
 				sort.Sort(util.SortableInt64(data.OrigBytesList))
 			}
 			s.sortedCallback(data)

--- a/pkg/sniconn/analyzer.go
+++ b/pkg/sniconn/analyzer.go
@@ -96,7 +96,7 @@ func tlsQuery(datum *TLSInput, zeekRecords []*data.ZeekUIDRecord, strobeLimit in
 	// of connections in the current datum, don't store bytes and ts.
 	// it will not qualify to be downgraded to a beacon until this chunk is
 	// outdated and removed. If only importing once - still just a strobe.
-	ts := datum.Timestamps.Items()
+	ts := datum.Timestamps
 
 	var bytes []int64
 	var totalTwoWayBytes int64
@@ -149,7 +149,7 @@ func httpQuery(datum *HTTPInput, zeekRecords []*data.ZeekUIDRecord, strobeLimit 
 	// of connections in the current datum, don't store bytes and ts.
 	// it will not qualify to be downgraded to a beacon until this chunk is
 	// outdated and removed. If only importing once - still just a strobe.
-	ts := datum.Timestamps.Items()
+	ts := datum.Timestamps
 
 	var bytes []int64
 	var totalTwoWayBytes int64

--- a/pkg/sniconn/repository.go
+++ b/pkg/sniconn/repository.go
@@ -32,7 +32,7 @@ type TLSInput struct {
 	IsLocalSrc bool
 
 	ConnectionCount int64
-	Timestamps      data.Int64Set
+	Timestamps      []int64
 	RespondingIPs   data.UniqueIPSet
 	RespondingPorts data.IntSet
 
@@ -50,7 +50,7 @@ type HTTPInput struct {
 	IsLocalSrc bool
 
 	ConnectionCount int64
-	Timestamps      data.Int64Set
+	Timestamps      []int64
 	RespondingIPs   data.UniqueIPSet
 	RespondingPorts data.IntSet
 

--- a/pkg/uconn/repository.go
+++ b/pkg/uconn/repository.go
@@ -28,6 +28,7 @@ type Input struct {
 	MaxDuration     float64
 	TotalDuration   float64
 	TsList          []int64
+	TsListFull      []int64
 	OrigBytesList   []int64
 	Tuples          data.StringSet
 	InvalidCertFlag bool

--- a/pkg/uconnproxy/repository.go
+++ b/pkg/uconnproxy/repository.go
@@ -27,6 +27,7 @@ type update struct {
 type Input struct {
 	Hosts           data.UniqueSrcFQDNPair
 	TsList          []int64
+	TsListFull      []int64
 	Proxy           data.UniqueIP
 	ConnectionCount int64
 }


### PR DESCRIPTION
This is a patch to store every timestamp in the uconn ts list rather than a unique set. This will not impact any of the scoring algorithms, which already gather the timestamps with `$addToSet`