### PR TITLE
Fixed some beacon scores from being NaN

### DIFF
--- a/pkg/beacon/analyzer.go
+++ b/pkg/beacon/analyzer.go
@@ -178,7 +178,7 @@ func (a *analyzer) start() {
 
 				//lower dispersion is better
 				dsMadmScore := 1.0 - float64(dsMadm)/float64(dsMid)
-				if dsMadmScore < 0 {
+				if dsMadmScore < 0 || math.IsNaN(dsMadmScore) {
 					dsMadmScore = 0
 				}
 

--- a/pkg/beacon/analyzer.go
+++ b/pkg/beacon/analyzer.go
@@ -177,8 +177,11 @@ func (a *analyzer) start() {
 				}
 
 				//lower dispersion is better
-				dsMadmScore := 1.0 - float64(dsMadm)/float64(dsMid)
-				if dsMadmScore < 0 || math.IsNaN(dsMadmScore) {
+				dsMadmScore := 0.0
+				if dsMid >= 1 {
+					dsMadmScore = 1.0 - float64(dsMadm)/float64(dsMid)
+				}
+				if dsMadmScore < 0 {
 					dsMadmScore = 0
 				}
 


### PR DESCRIPTION
Added a check when calculating `dsMadmScore` to set it to `0` if it is less than zero or `NaN`. 
During my troubleshooting, I noted that only `dsScore` had instances of `NaN`.  It looks like the other score parameters have checks for dividing by zero.
Tested and confirmed that previously `NaN` scored beacons now have real scores.