### PR TITLE
Filter external to internal traffic by default

### DIFF
--- a/config/static.go
+++ b/config/static.go
@@ -127,7 +127,7 @@ type (
 		InternalSubnets          []string `yaml:"InternalSubnets" default:"[\"10.0.0.0/8\", \"172.16.0.0/12\", \"192.168.0.0/16\"]"`
 		AlwaysIncludeDomain      []string `yaml:"AlwaysIncludeDomain" default:"[]"`
 		NeverIncludeDomain       []string `yaml:"NeverIncludeDomain" default:"[]"`
-		FilterExternalToInternal bool     `yaml:"FilterExternalToInternal" default:"false"`
+		FilterExternalToInternal bool     `yaml:"FilterExternalToInternal" default:"true"`
 	}
 
 	//StrobeStaticCfg controls the maximum number of connections between any two given hosts

--- a/etc/rita.yaml
+++ b/etc/rita.yaml
@@ -102,7 +102,7 @@ Filtering:
 
   # FilterExternalToInternal will ignore any entries where communication
   # is occurring from an external host to an internal host
-  FilterExternalToInternal: false
+  FilterExternalToInternal: true
 
 BlackListed:
   Enabled: true


### PR DESCRIPTION
This PR enables the filter which drops external to internal traffic by default. This can be turned off by changing the `FilterExternalToInternal` field in the RITA config file back to false.

To test the changes, I  commented out the `FilterExternalToInternal` field in my RITA config and ran `rita test-config`. The filter was then enabled by default.