### PR TITLE
Fix beaconFQDN crash when analyzing large amounts of data

### DIFF
--- a/pkg/beaconfqdn/mongodb.go
+++ b/pkg/beaconfqdn/mongodb.go
@@ -252,19 +252,19 @@ func (r *repo) Upsert(hostMap map[string]*host.Input, minTimestamp, maxTimestamp
 // traffic in this run. Each hostname entry is returned along with its list of associated resolved IPs.
 func (r *repo) affectedHostnameIPs(hostMap map[string]*host.Input) ([]hostnameIPs, error) {
 
-	// We can only submit around 200,000 hosts in a single query to MongoDB due to the 16MB document limit.
-	// 1 Megabyte / Size of Unique IP BSON query ~= 200,000
-	// 16 * 1024 * 1024 / (64 for IPv4, 83 for IPv6) = (262144 for IPv4, 202135 for IPv6)
+	// We can only submit around 150,000 hosts in a single query to MongoDB due to the 16MB document limit.
+	// 1 Megabyte / Size of Unique IP BSON query ~= 150,000
+	// 16 * 1024 * 1024 / (89 for IPv4, 104 for IPv6) = (188508 for IPv4, 161319 for IPv6)
 
-	// provide a fast path for datasets with less than 200,000 hosts
-	if len(hostMap) <= 200000 {
+	// provide a fast path for datasets with less than 150,000 hosts
+	if len(hostMap) <= 150000 {
 		return r.affectedHostnameIPsSimple(hostMap)
 	}
 	return r.affectedHostnameIPsChunked(hostMap)
 }
 
 // affectedHostnameIPsSimple implements affectedHostnameIPs but should only be called with hostMaps with
-// roughly less than 200,000 external hosts.
+// roughly less than 150,000 external hosts.
 func (r *repo) affectedHostnameIPsSimple(hostMap map[string]*host.Input) ([]hostnameIPs, error) {
 	// preallocate externalHosts slice assuming at least half of the observed hosts are external
 	// In most implementations of the Go runtime, when the array underlying a slice is
@@ -301,13 +301,13 @@ func (r *repo) affectedHostnameIPsChunked(hostMap map[string]*host.Input) ([]hos
 	// reallocated via append(), the runtime will double the size of the underlying array.
 	// With this assumption in mind, we can assume that externalHosts will be reallocated
 	// only one time at most.
-	externalHosts := make([]data.UniqueIP, 0, util.Min(200000, len(hostMap)/2))
+	externalHosts := make([]data.UniqueIP, 0, util.Min(150000, len(hostMap)/2))
 	var affectedHostnamesBuffer []hostnameIPs
 
 	ssn := r.database.Session.Copy()
 	defer ssn.Close()
 
-	// we will need to remove duplicate results from each query of 200,000 hosts, slowing down the process
+	// we will need to remove duplicate results from each query of 150,000 hosts, slowing down the process
 	// and consuming more RAM
 
 	// affectedHostnameIPMap maps hostnames to their respective ResolvedIPs
@@ -322,7 +322,7 @@ func (r *repo) affectedHostnameIPsChunked(hostMap map[string]*host.Input) ([]hos
 
 		externalHosts = append(externalHosts, host.Host)
 
-		if len(externalHosts) == 200000 { // we've hit the limit, run the MongoDB query
+		if len(externalHosts) == 150000 { // we've hit the limit, run the MongoDB query
 			reverseDNSagg := reverseDNSQueryWithIPs(externalHosts)
 			externalHosts = externalHosts[:0] // clear externalHosts to make room for the next chunk
 


### PR DESCRIPTION
This PR lowers the bulk lookup limit in the beaconFQDN queries which map IP addresses in the parse set to domain names in the hostname collection. It is currently set to 200,000 lookups. The limit was put in place to prevent hitting the 16MB MongoDB  document ceiling while maximizing performance. However, the limit was set too high, and RITA ends up hitting the ceiling anyways in some cases. As a result, the beaconFQDN analysis may crash. 

The previous limit incorrectly estimated the size of the Unique IP lookup BSON documents. In order to get a better estimate, I wrote a separate piece of code to generate, serialize, and measure the length of the longest possible IPv4 and IPv6 lookups. After obtaining the new estimates, I came up with a new value for the threshold. The new limit is set to 150,000 lookups and allows each lookup to take up to 111 bytes. In my testing with IPv6 addresses, I could not generate a lookup longer than 104 bytes. 

Additionally, we can estimate the size of each lookup from the error case that was reported. The BSON document in the error that was reported was 17096531 bytes long. We know that this document contained 200,000 lookups. Dividing it out, we see that each lookup took around 86 bytes. Since the new limit handles lookups averaging up to 111 bytes each, the new limit will handle this error in the future.

Fixes #759 

