### PR TITLE
Filter out proxy traffic which occurs over the internal network

### DIFF
--- a/parser/http.go
+++ b/parser/http.go
@@ -78,6 +78,10 @@ func parseHTTPEntry(parseHTTP *parsetypes.HTTP, filter filter, retVals ParseResu
 		if filter.filterDomain(fqdn) || filter.filterSingleIP(srcIP) {
 			return
 		}
+		fqdnAsIPAddress := net.ParseIP(fqdn)
+		if fqdnAsIPAddress != nil && filter.checkIfInternal(dstIP) && filter.filterConnPair(srcIP, fqdnAsIPAddress) {
+			return
+		}
 	} else if filter.filterDomain(fqdn) || filter.filterConnPair(srcIP, dstIP) {
 		return
 	}


### PR DESCRIPTION
This PR adds a filter to the parser which filters out HTTP proxy connection entries if the source, proxy, and destination are all internal IP addresses. 

I tested this by adding the following entry to an http.log file and ensuring that the new code filtered out the resulting document int he `proxyUconn` collection.
```
1610645063.451000       CapEgukOzsRcJpPde       192.168.0.15    34705   10.10.10.10     1080    1       CONNECT 10.20.20.20     10.20.20.20:443 -       -       Mozilla/5.0 (Windows NT 6.1; Win64; x64; rv:84.0) Gecko/20100101 Firefox/84.0   0       0       -       -       -       -       (empty) -       -       PROXY-CONNECTION -> keep-alive  -       -       -       -       -       -
```
