### PR TITLE
Fix RITA clean 'no such command "scale"' error

### DIFF
--- a/commands/clean.go
+++ b/commands/clean.go
@@ -102,9 +102,9 @@ func cleanDatabase(c *cli.Context) error {
 			IndexSize int64 `bson:"indexSize"`
 		}
 
-		err = session.DB(matchingDB).Run(bson.M{
-			"dbStats": 1,
-			"scale":   1024 * 1024,
+		err = session.DB(matchingDB).Run(bson.D{
+			{Name: "dbStats", Value: 1},
+			{Name: "scale", Value: 1024 * 1024},
 		}, &dbSize)
 
 		if err != nil {


### PR DESCRIPTION
If the `scale` field appears before `dbStats` when asking MongoDB the size of a collection, the command will fail. The RITA clean command stores this query document using `bson.M` which does not guarantee the order of the fields. As a result, the command will fail at random. This PR ensures that RITA uses `bson.D` to store this query document. This preserves the order of the fields each time the code is executed.

Fixes #770 

Example mongo shell output:

```
> db.getSiblingDB("testdb-2022-11-21").runCommand({ "scale": 1024 * 1024, "dbStats": 1})
{
        "ok" : 0,
        "errmsg" : "no such command: 'scale'",
        "code" : 59,
        "codeName" : "CommandNotFound"
}
> db.getSiblingDB("testdb-2022-11-21").runCommand({"dbStats": 1, "scale": 1024 * 1024})
{
        "db" : "testdb-2022-11-21",
        "collections" : 11,
        "views" : 0,
        "objects" : 1017028,
        "avgObjSize" : 762.0969314512481,
        "dataSize" : 739.1680889129639,
        "storageSize" : 244.2265625,
        "numExtents" : 0,
        "indexes" : 59,
        "indexSize" : 95.8359375,
        "scaleFactor" : 1048576,
        "fsUsedSize" : 1208142.41015625,
        "fsTotalSize" : 1625364.50390625,
        "ok" : 1
}
```