### PR TITLE
Fix SSL and DNS log filtering

### DIFF
--- a/parser/ssl.go
+++ b/parser/ssl.go
@@ -35,14 +35,14 @@ func parseSSLEntry(parseSSL *parsetypes.SSL, filter filter, retVals ParseResults
 
 	srcFQDNKey := srcFQDNPair.MapKey()
 
-	updateUseragentsBySSL(srcUniqIP, parseSSL, retVals)
-
 	// create uconn and cert records
 	// Run conn pair through filter to filter out certain connections
-	ignore := filter.filterConnPair(srcIP, dstIP)
+	ignore := filter.filterDomain(fqdn) || filter.filterConnPair(srcIP, dstIP)
 	if ignore {
 		return
 	}
+
+	updateUseragentsBySSL(srcUniqIP, parseSSL, retVals)
 
 	certificateIsInvalid := certStatus != "ok" && certStatus != "-" && certStatus != "" && certStatus != " "
 


### PR DESCRIPTION
- The SSL log filter did not check the FQDN in each entry against the always and never include lists in the filter. This has been fixed. SNI beacons and JA3 hashes can now be excluded by hostname.
- The DNS log filter did not filter out internal -> internal traffic or external -> internal traffic. This was originally implemented to ensure that traffic to internal DNS resolvers was analyzed. However, this was implemented before we had the always include list. This PR ensures that the DNS log filter matches the associated Conn log filter on the IP level. When deploying RITA, any internal DNS resolvers should always be added to the IP always include list. 