### PR TITLE
Parsed log field validation

### DIFF
--- a/parser/conn.go
+++ b/parser/conn.go
@@ -10,9 +10,12 @@ import (
 	"github.com/activecm/rita/pkg/host"
 	"github.com/activecm/rita/pkg/uconn"
 	"github.com/activecm/rita/util"
+
+	log "github.com/sirupsen/logrus"
 )
 
-func parseConnEntry(parseConn *parsetypes.Conn, filter filter, retVals ParseResults) {
+func parseConnEntry(parseConn *parsetypes.Conn, filter filter, retVals ParseResults, logger *log.Logger) {
+
 	// get source destination pair for connection record
 	src := parseConn.Source
 	dst := parseConn.Destination
@@ -20,6 +23,16 @@ func parseConnEntry(parseConn *parsetypes.Conn, filter filter, retVals ParseResu
 	// parse addresses into binary format
 	srcIP := net.ParseIP(src)
 	dstIP := net.ParseIP(dst)
+
+	// verify that both addresses were parsed successfully
+	if (srcIP == nil) || (dstIP == nil) {
+		logger.WithFields(log.Fields{
+			"uid": parseConn.UID,
+			"src": parseConn.Source,
+			"dst": parseConn.Destination,
+		}).Error("Unable to parse valid ip address pair from conn log entry, skipping entry.")
+		return
+	}
 
 	// Run conn pair through filter to filter out certain connections
 	ignore := filter.filterConnPair(srcIP, dstIP)

--- a/parser/dns.go
+++ b/parser/dns.go
@@ -25,7 +25,7 @@ func parseDNSEntry(parseDNS *parsetypes.DNS, filter filter, retVals ParseResults
 			"uid": parseDNS.UID,
 			"src": parseDNS.Source,
 			"dst": parseDNS.Destination,
-		}).Error("Unable to parse valid ip address pair from http log entry, skipping entry.")
+		}).Error("Unable to parse valid ip address pair from dns log entry, skipping entry.")
 		return
 	}
 

--- a/parser/dns.go
+++ b/parser/dns.go
@@ -6,20 +6,43 @@ import (
 	"github.com/activecm/rita/parser/parsetypes"
 	"github.com/activecm/rita/pkg/data"
 	"github.com/activecm/rita/pkg/hostname"
+
+	log "github.com/sirupsen/logrus"
 )
 
-func parseDNSEntry(parseDNS *parsetypes.DNS, filter filter, retVals ParseResults) {
+func parseDNSEntry(parseDNS *parsetypes.DNS, filter filter, retVals ParseResults, logger *log.Logger) {
 
 	// extract and store the dns client ip address
 	src := parseDNS.Source
 	srcIP := net.ParseIP(src)
+
+	// verify that ip address was parsed successfully
+	if srcIP == nil {
+		logger.WithFields(log.Fields{
+			"uid": parseDNS.UID,
+			"src": parseDNS.Source,
+		}).Error("Unable to get valid client ip address from dns log entry, skipping entry.")
+		return
+	}
+
+	// get domain
+	domain := parseDNS.Query
+
+	// verify that domain was parsed successfully
+	if domain == "" {
+		logger.WithFields(log.Fields{
+			"uid":   parseDNS.UID,
+			"query": parseDNS.Query,
+		}).Error("Unable to parse valid domain from dns log entry, skipping entry.")
+		return
+	}
 
 	// Run domain through filter to filter out certain domains
 	// We don't filter out the src ips like we do with the conn
 	// section since a c2 channel running over dns could have an
 	// internal ip to internal ip connection and not having that ip
 	// in the host table is limiting
-	ignore := (filter.filterDomain(parseDNS.Query) || filter.filterSingleIP(srcIP))
+	ignore := (filter.filterDomain(domain) || filter.filterSingleIP(srcIP))
 
 	// If domain is not subject to filtering, process
 	if ignore {
@@ -28,33 +51,33 @@ func parseDNSEntry(parseDNS *parsetypes.DNS, filter filter, retVals ParseResults
 
 	srcUniqIP := data.NewUniqueIP(srcIP, parseDNS.AgentUUID, parseDNS.AgentHostname)
 
-	updateExplodedDNSbyDNS(parseDNS, retVals)
-	updateHostnamesByDNS(srcUniqIP, parseDNS, retVals)
+	updateExplodedDNSbyDNS(domain, retVals)
+	updateHostnamesByDNS(srcUniqIP, domain, parseDNS, retVals)
 }
 
-func updateExplodedDNSbyDNS(parseDNS *parsetypes.DNS, retVals ParseResults) {
+func updateExplodedDNSbyDNS(domain string, retVals ParseResults) {
 
 	retVals.ExplodedDNSLock.Lock()
 	defer retVals.ExplodedDNSLock.Unlock()
 
-	retVals.ExplodedDNSMap[parseDNS.Query]++
+	retVals.ExplodedDNSMap[domain]++
 }
 
-func updateHostnamesByDNS(srcUniqIP data.UniqueIP, parseDNS *parsetypes.DNS, retVals ParseResults) {
+func updateHostnamesByDNS(srcUniqIP data.UniqueIP, domain string, parseDNS *parsetypes.DNS, retVals ParseResults) {
 
 	retVals.HostnameLock.Lock()
 	defer retVals.HostnameLock.Unlock()
 
-	if _, ok := retVals.HostnameMap[parseDNS.Query]; !ok {
-		retVals.HostnameMap[parseDNS.Query] = &hostname.Input{
-			Host:        parseDNS.Query,
+	if _, ok := retVals.HostnameMap[domain]; !ok {
+		retVals.HostnameMap[domain] = &hostname.Input{
+			Host:        domain,
 			ClientIPs:   make(data.UniqueIPSet),
 			ResolvedIPs: make(data.UniqueIPSet),
 		}
 	}
 
 	// ///// UNION SOURCE HOST INTO HOSTNAME CLIENT SET /////
-	retVals.HostnameMap[parseDNS.Query].ClientIPs.Insert(srcUniqIP)
+	retVals.HostnameMap[domain].ClientIPs.Insert(srcUniqIP)
 
 	// ///// UNION HOST ANSWERS INTO HOSTNAME RESOLVED HOST SET /////
 	if parseDNS.QTypeName == "A" {
@@ -63,7 +86,7 @@ func updateHostnamesByDNS(srcUniqIP data.UniqueIP, parseDNS *parsetypes.DNS, ret
 			// Check if answer is an IP address and store it if it is
 			if answerIP != nil {
 				answerUniqIP := data.NewUniqueIP(answerIP, parseDNS.AgentUUID, parseDNS.AgentHostname)
-				retVals.HostnameMap[parseDNS.Query].ResolvedIPs.Insert(answerUniqIP)
+				retVals.HostnameMap[domain].ResolvedIPs.Insert(answerUniqIP)
 			}
 		}
 	}

--- a/parser/dns.go
+++ b/parser/dns.go
@@ -28,15 +28,6 @@ func parseDNSEntry(parseDNS *parsetypes.DNS, filter filter, retVals ParseResults
 	// get domain
 	domain := parseDNS.Query
 
-	// verify that domain was parsed successfully
-	if domain == "" {
-		logger.WithFields(log.Fields{
-			"uid":   parseDNS.UID,
-			"query": parseDNS.Query,
-		}).Error("Unable to parse valid domain from dns log entry, skipping entry.")
-		return
-	}
-
 	// Run domain through filter to filter out certain domains
 	// We don't filter out the src ips like we do with the conn
 	// section since a c2 channel running over dns could have an

--- a/parser/fsimporter.go
+++ b/parser/fsimporter.go
@@ -168,6 +168,7 @@ func (fs *FSImporter) Run(indexedFiles []*files.IndexedFile, threads int) {
 
 		// parse in those files!
 		retVals := fs.parseFiles(indexedFileBatch, threads, fs.log)
+
 		// Set chunk before we continue so if process dies, we still verify with a delete if
 		// any data was written out.
 		fs.metaDB.SetChunk(fs.config.S.Rolling.CurrentChunk, fs.database.GetSelectedDB(), true)
@@ -371,15 +372,15 @@ func (fs *FSImporter) parseFiles(indexedFiles []*files.IndexedFile, parsingThrea
 
 					switch typedEntry := entry.(type) {
 					case *parsetypes.Conn:
-						parseConnEntry(typedEntry, fs.filter, retVals)
+						parseConnEntry(typedEntry, fs.filter, retVals, logger)
 					case *parsetypes.DNS:
-						parseDNSEntry(typedEntry, fs.filter, retVals)
+						parseDNSEntry(typedEntry, fs.filter, retVals, logger)
 					case *parsetypes.HTTP:
-						parseHTTPEntry(typedEntry, fs.filter, retVals)
+						parseHTTPEntry(typedEntry, fs.filter, retVals, logger)
 					case *parsetypes.OpenConn:
-						parseOpenConnEntry(typedEntry, fs.filter, retVals)
+						parseOpenConnEntry(typedEntry, fs.filter, retVals, logger)
 					case *parsetypes.SSL:
-						parseSSLEntry(typedEntry, fs.filter, retVals)
+						parseSSLEntry(typedEntry, fs.filter, retVals, logger)
 					}
 				}
 				indexedFiles[j].ParseTime = time.Now()

--- a/parser/http.go
+++ b/parser/http.go
@@ -72,9 +72,10 @@ func parseHTTPEntry(parseHTTP *parsetypes.HTTP, filter filter, retVals ParseResu
 				"uri":  parseHTTP.URI,
 			}).Error("Unable to parse valid fqdn from http log entry, skipping entry.")
 			return
-		} else {
-			fqdn = uri
 		}
+
+		fqdn = uri
+
 	}
 
 	// parse method type

--- a/parser/http.go
+++ b/parser/http.go
@@ -64,16 +64,6 @@ func parseHTTPEntry(parseHTTP *parsetypes.HTTP, filter filter, retVals ParseResu
 		uri = uri[:maxIndex]
 
 		// at this point, the URI should be parsed down to just an FQDN
-		// set fqdn or skip log entry if still unable to parse value
-		if uri == "" {
-			logger.WithFields(log.Fields{
-				"uid":  parseHTTP.UID,
-				"host": parseHTTP.Host,
-				"uri":  parseHTTP.URI,
-			}).Error("Unable to parse valid fqdn from http log entry, skipping entry.")
-			return
-		}
-
 		fqdn = uri
 
 	}

--- a/parser/http.go
+++ b/parser/http.go
@@ -9,9 +9,11 @@ import (
 	"github.com/activecm/rita/pkg/sniconn"
 	"github.com/activecm/rita/pkg/uconnproxy"
 	"github.com/activecm/rita/pkg/useragent"
+
+	log "github.com/sirupsen/logrus"
 )
 
-func parseHTTPEntry(parseHTTP *parsetypes.HTTP, filter filter, retVals ParseResults) {
+func parseHTTPEntry(parseHTTP *parsetypes.HTTP, filter filter, retVals ParseResults, logger *log.Logger) {
 	// get source destination pair for connection record
 	src := parseHTTP.Source
 	dst := parseHTTP.Destination
@@ -19,6 +21,16 @@ func parseHTTPEntry(parseHTTP *parsetypes.HTTP, filter filter, retVals ParseResu
 	// parse addresses into binary format
 	srcIP := net.ParseIP(src)
 	dstIP := net.ParseIP(dst)
+
+	// verify that both addresses were able to be parsed successfully
+	if (srcIP == nil) || (dstIP == nil) {
+		logger.WithFields(log.Fields{
+			"uid": parseHTTP.UID,
+			"src": parseHTTP.Source,
+			"dst": parseHTTP.Destination,
+		}).Error("Unable to parse valid ip address pair from http log entry, skipping entry.")
+		return
+	}
 
 	// parse host
 	fqdn := parseHTTP.Host
@@ -52,7 +64,17 @@ func parseHTTPEntry(parseHTTP *parsetypes.HTTP, filter filter, retVals ParseResu
 		uri = uri[:maxIndex]
 
 		// at this point, the URI should be parsed down to just an FQDN
-		fqdn = uri
+		// set fqdn or skip log entry if still unable to parse value
+		if uri == "" {
+			logger.WithFields(log.Fields{
+				"uid":  parseHTTP.UID,
+				"host": parseHTTP.Host,
+				"uri":  parseHTTP.URI,
+			}).Error("Unable to parse valid fqdn from http log entry, skipping entry.")
+			return
+		} else {
+			fqdn = uri
+		}
 	}
 
 	// parse method type

--- a/parser/ssl.go
+++ b/parser/ssl.go
@@ -37,15 +37,6 @@ func parseSSLEntry(parseSSL *parsetypes.SSL, filter filter, retVals ParseResults
 	// get fqdn
 	fqdn := parseSSL.ServerName
 
-	// verify that fqdn was parsed successfully
-	if fqdn == "" {
-		logger.WithFields(log.Fields{
-			"uid":         parseSSL.UID,
-			"server_name": parseSSL.ServerName,
-		}).Error("Unable to parse valid fqdn from ssl log entry, skipping entry.")
-		return
-	}
-
 	srcUniqIP := data.NewUniqueIP(srcIP, parseSSL.AgentUUID, parseSSL.AgentHostname)
 	dstUniqIP := data.NewUniqueIP(dstIP, parseSSL.AgentUUID, parseSSL.AgentHostname)
 	srcDstPair := data.NewUniqueIPPair(srcUniqIP, dstUniqIP)


### PR DESCRIPTION
This PR adds some checks in the log ingestion process. The checks validate that the bare minimum fields required for processing into a collection are present in a log entry before attempting to further parse that long entry for that collection. This was prompted by some malformed/incomplete ip addresses causing RITA to crash.