### PR TITLE
Removal of connection count portion of beacon scoring and adjustment of skew

### DIFF
--- a/config/static.go
+++ b/config/static.go
@@ -22,6 +22,12 @@ import (
 // within ~16777216 bytes
 const maxStrobeConnectionLimit int = 86400
 
+// Define the mimimum connection limit for beacon analysis. Currently we require a 24
+// hour block of data for a dataset. Analyzing hosts that have fewer than at least one
+// connection per hour could significantly increase both the analysis time and the number
+// of false positives, so the threshold must be 23 or above.
+const minBeaconConnectionThreshLimit int = 23
+
 type (
 	//StaticCfg is the container for other static config sections
 	StaticCfg struct {
@@ -96,7 +102,7 @@ type (
 	//BeaconStaticCfg is used to control the beaconing analysis module
 	BeaconStaticCfg struct {
 		Enabled                 bool    `yaml:"Enabled" default:"true"`
-		DefaultConnectionThresh int     `yaml:"DefaultConnectionThresh" default:"20"`
+		DefaultConnectionThresh int     `yaml:"DefaultConnectionThresh" default:"23"`
 		TsWeight                float64 `yaml:"TimestampScoreWeight" default:"0.25"`
 		DsWeight                float64 `yaml:"DatasizeScoreWeight" default:"0.25"`
 		DurWeight               float64 `yaml:"DurationScoreWeight" default:"0.25"`
@@ -106,7 +112,7 @@ type (
 	//BeaconProxyStaticCfg is used to control the proxy beaconing analysis module
 	BeaconProxyStaticCfg struct {
 		Enabled                 bool    `yaml:"Enabled" default:"true"`
-		DefaultConnectionThresh int     `yaml:"DefaultConnectionThresh" default:"20"`
+		DefaultConnectionThresh int     `yaml:"DefaultConnectionThresh" default:"23"`
 		TsWeight                float64 `yaml:"TimestampScoreWeight" default:"0.333"`
 		DurWeight               float64 `yaml:"DurationScoreWeight" default:"0.333"`
 		HistWeight              float64 `yaml:"HistogramScoreWeight" default:"0.333"`
@@ -115,7 +121,7 @@ type (
 	//BeaconSNIStaticCfg is used to control the SNI beaconing analysis module
 	BeaconSNIStaticCfg struct {
 		Enabled                 bool    `yaml:"Enabled" default:"true"`
-		DefaultConnectionThresh int     `yaml:"DefaultConnectionThresh" default:"20"`
+		DefaultConnectionThresh int     `yaml:"DefaultConnectionThresh" default:"23"`
 		TsWeight                float64 `yaml:"TimestampScoreWeight" default:"0.25"`
 		DsWeight                float64 `yaml:"DatasizeScoreWeight" default:"0.25"`
 		DurWeight               float64 `yaml:"DurationScoreWeight" default:"0.25"`
@@ -183,6 +189,21 @@ func parseStaticConfig(cfgFile []byte, config *StaticCfg) error {
 	// limit the strobe connection limit to the maximum allowed
 	if config.Strobe.ConnectionLimit > maxStrobeConnectionLimit {
 		config.Strobe.ConnectionLimit = maxStrobeConnectionLimit
+	}
+
+	// limit the beacon threshold to the minimum allowed
+	if config.Beacon.DefaultConnectionThresh < minBeaconConnectionThreshLimit {
+		config.Beacon.DefaultConnectionThresh = minBeaconConnectionThreshLimit
+	}
+
+	// limit the beacon sni threshold to the minimum allowed
+	if config.BeaconSNI.DefaultConnectionThresh < minBeaconConnectionThreshLimit {
+		config.BeaconSNI.DefaultConnectionThresh = minBeaconConnectionThreshLimit
+	}
+
+	// limit the beacon proxy threshold to the minimum allowed
+	if config.BeaconProxy.DefaultConnectionThresh < minBeaconConnectionThreshLimit {
+		config.BeaconProxy.DefaultConnectionThresh = minBeaconConnectionThreshLimit
 	}
 
 	// expand env variables, config is a pointer

--- a/config/static.go
+++ b/config/static.go
@@ -22,7 +22,7 @@ import (
 // within ~16777216 bytes
 const maxStrobeConnectionLimit int = 86400
 
-// Define the mimimum connection limit for beacon analysis. Currently we require a 24
+// Define the minimum connection limit for beacon analysis. Currently we require a 24
 // hour block of data for a dataset. Analyzing hosts that have fewer than at least one
 // connection per hour could significantly increase both the analysis time and the number
 // of false positives, so the threshold must be 23 or above.

--- a/config/static_test.go
+++ b/config/static_test.go
@@ -162,5 +162,5 @@ LogConfig:
 	testConfigExp.ExactVersion = config.ExactVersion
 
 	assert.Nil(t, err)
-	assert.Equal(t, *config, testConfigExp)
+	assert.Equal(t, config.Log, testConfigExp.Log)
 }

--- a/config/static_test.go
+++ b/config/static_test.go
@@ -33,21 +33,21 @@ DNS:
     Enabled: true
 Beacon:
     Enabled: true
-    DefaultConnectionThresh: 20
+    DefaultConnectionThresh: 5
     TimestampScoreWeight: 0.25
     DatasizeScoreWeight: 0.25
     DurationScoreWeight: 0.25
     HistogramScoreWeight: 0.25
 BeaconSNI:
     Enabled: true
-    DefaultConnectionThresh: 20
+    DefaultConnectionThresh: 5
     TimestampScoreWeight: 0.25
     DatasizeScoreWeight: 0.25
     DurationScoreWeight: 0.25
     HistogramScoreWeight: 0.25
 BeaconProxy:
     Enabled: true
-    DefaultConnectionThresh: 20
+    DefaultConnectionThresh: 5
     TimestampScoreWeight: 0.333
     DurationScoreWeight: 0.333
     HistogramScoreWeight: 0.333
@@ -94,7 +94,7 @@ var testConfigFullExp = StaticCfg{
 	},
 	Beacon: BeaconStaticCfg{
 		Enabled:                 true,
-		DefaultConnectionThresh: 20,
+		DefaultConnectionThresh: minBeaconConnectionThreshLimit,
 		TsWeight:                0.25,
 		DsWeight:                0.25,
 		DurWeight:               0.25,
@@ -102,7 +102,7 @@ var testConfigFullExp = StaticCfg{
 	},
 	BeaconSNI: BeaconSNIStaticCfg{
 		Enabled:                 true,
-		DefaultConnectionThresh: 20,
+		DefaultConnectionThresh: minBeaconConnectionThreshLimit,
 		TsWeight:                0.25,
 		DsWeight:                0.25,
 		DurWeight:               0.25,
@@ -110,7 +110,7 @@ var testConfigFullExp = StaticCfg{
 	},
 	BeaconProxy: BeaconProxyStaticCfg{
 		Enabled:                 true,
-		DefaultConnectionThresh: 20,
+		DefaultConnectionThresh: minBeaconConnectionThreshLimit,
 		TsWeight:                0.333,
 		DurWeight:               0.333,
 		HistWeight:              0.333,

--- a/config/testing.go
+++ b/config/testing.go
@@ -31,21 +31,21 @@ DNS:
     Enabled: true
 Beacon:
     Enabled: true
-    DefaultConnectionThresh: 20
+    DefaultConnectionThresh: 23
     TimestampScoreWeight: 0.25
     DatasizeScoreWeight: 0.25
     DurationScoreWeight: 0.25
     HistogramScoreWeight: 0.25
 BeaconSNI:
     Enabled: true
-    DefaultConnectionThresh: 20
+    DefaultConnectionThresh: 23
     TimestampScoreWeight: 0.25
     DatasizeScoreWeight: 0.25
     DurationScoreWeight: 0.25
     HistogramScoreWeight: 0.25
 BeaconProxy:
     Enabled: true
-    DefaultConnectionThresh: 20
+    DefaultConnectionThresh: 23
     TimestampScoreWeight: 0.333
     DurationScoreWeight: 0.333
     HistogramScoreWeight: 0.333

--- a/etc/rita.yaml
+++ b/etc/rita.yaml
@@ -131,15 +131,14 @@ BlackListed:
 Beacon:
   Enabled: true
   # The default minimum number of connections used for beacons analysis.
-  # Any two hosts connecting fewer than this number will not be analyzed.
-  # 20 was chosen as it is a little bit less than once per hour in a day,
-  # and allows for any packet loss that could occur.
-
-  # If you choose a lower value, this will significantly increase both
-  # the analysis time and the number of false positives. You can safely
-  # increase this value to improve performance if you are not concerned
+  # Any two hosts connecting fewer than this number will not be analyzed. You can 
+  # safely increase this value to improve performance if you are not concerned
   # about slow beacons.
-  DefaultConnectionThresh: 20
+
+  # Note: Since analyzing hosts that have fewer than at least one connection per 
+  # hour could significantly increase both the analysis time and the number
+  # of false positives, 23 is the minimum allowed value for this field.
+  DefaultConnectionThresh: 23
 
   # The score is currently comprised of a weighted average of 4 subscores.
   # While we recommend the default setting of 0.25 for each weight, 
@@ -153,15 +152,14 @@ Beacon:
 BeaconSNI:
   Enabled: true
   # The default minimum number of connections used for beacons SNI analysis.
-  # Any two hosts connecting fewer than this number will not be analyzed.
-  # 20 was chosen as it is a little bit less than once per hour in a day,
-  # and allows for any packet loss that could occur.
-
-  # If you choose a lower value, this will significantly increase both
-  # the analysis time and the number of false positives. You can safely
-  # increase this value to improve performance if you are not concerned
+  # Any two hosts connecting fewer than this number will not be analyzed. You can 
+  # safely increase this value to improve performance if you are not concerned
   # about slow beacons.
-  DefaultConnectionThresh: 20
+
+  # Note: Since analyzing hosts that have fewer than at least one connection per 
+  # hour could significantly increase both the analysis time and the number
+  # of false positives, 23 is the minimum allowed value for this field.
+  DefaultConnectionThresh: 23
 
   # The score is currently comprised of a weighted average of 4 subscores.
   # While we recommend the default setting of 0.25 for each weight, 
@@ -175,15 +173,14 @@ BeaconSNI:
 BeaconProxy:
   Enabled: true
   # The default minimum number of connections used for beacons proxy analysis.
-  # Any two hosts connecting fewer than this number will not be analyzed.
-  # 20 was chosen as it is a little bit less than once per hour in a day,
-  # and allows for any packet loss that could occur.
-
-  # If you choose a lower value, this will significantly increase both
-  # the analysis time and the number of false positives. You can safely
-  # increase this value to improve performance if you are not concerned
+  # Any two hosts connecting fewer than this number will not be analyzed. You can 
+  # safely increase this value to improve performance if you are not concerned
   # about slow beacons.
-  DefaultConnectionThresh: 20
+
+  # Note: Since analyzing hosts that have fewer than at least one connection per 
+  # hour could significantly increase both the analysis time and the number
+  # of false positives, 23 is the minimum allowed value for this field.
+  DefaultConnectionThresh: 23
 
   # The score is currently comprised of a weighted average of 3 subscores.
   # While we recommend the default setting of 0.333 for each weight, 
@@ -205,9 +202,9 @@ Strobe:
   # also trigger an entry in the strobe module. A lower value will reduce import & analysis time and
   # hide more potential false positives from other modules. A higher value will increase import &
   # analysis time, increase false positives, but reduce the risk of false negatives.
-  # Recommended values for this setting are:
+  
+  # Note: Since this value must be low enough to ensure that documents that store
+  # arrays based off of connections will not grow beyond 16MB in size, the maximum value allowed
+  # for this field is:
   #    86400 - One connection every second for 24 hours
-  #   700000 - Safe max value that is unlikely to cause errors
-  # The theoretical limit due to implementation limitations is ~1,048,573
-  # but in practice timeouts have occurred at lower values.
   ConnectionLimit: 86400

--- a/pkg/beacon/analyzer.go
+++ b/pkg/beacon/analyzer.go
@@ -120,11 +120,11 @@ func (a *analyzer) start() {
 
 			//tsSkew should equal zero if the denominator equals zero
 			//bowley skew is unreliable if Q2 = Q1 or Q2 = Q3
-			if tsBowleyDen != 0 && tsMid != tsLow && tsMid != tsHigh {
+			if tsBowleyDen >= 10 && tsMid != tsLow && tsMid != tsHigh {
 				tsSkew = float64(tsBowleyNum) / float64(tsBowleyDen)
 			}
 
-			if dsBowleyDen != 0 && dsMid != dsLow && dsMid != dsHigh {
+			if dsBowleyDen >= 10 && dsMid != dsLow && dsMid != dsHigh {
 				dsSkew = float64(dsBowleyNum) / float64(dsBowleyDen)
 			}
 
@@ -187,15 +187,8 @@ func (a *analyzer) start() {
 				dsSmallnessScore = 0
 			}
 
-			// connection count scoring
-			tsConnDiv := (float64(a.tsMax) - float64(a.tsMin)) / 3600
-			tsConnCountScore := float64(res.ConnectionCount) / tsConnDiv
-			if tsConnCountScore > 1.0 {
-				tsConnCountScore = 1.0
-			}
-
 			// calculate final ts and ds scores
-			tsScore := math.Ceil(((tsSkewScore+tsMadmScore+tsConnCountScore)/3.0)*1000) / 1000
+			tsScore := math.Ceil(((tsSkewScore+tsMadmScore)/2.0)*1000) / 1000
 			dsScore := math.Ceil(((dsSkewScore+dsMadmScore+dsSmallnessScore)/3.0)*1000) / 1000
 
 			// calculate duration score
@@ -227,7 +220,6 @@ func (a *analyzer) start() {
 					"ts.interval_counts": intervalCounts,
 					"ts.dispersion":      tsMadm,
 					"ts.skew":            tsSkew,
-					"ts.conns_score":     tsConnCountScore,
 					"ts.score":           tsScore,
 					"ds.range":           dsRange,
 					"ds.mode":            dsMode,

--- a/pkg/beaconproxy/analyzer.go
+++ b/pkg/beaconproxy/analyzer.go
@@ -112,7 +112,7 @@ func (a *analyzer) start() {
 
 			//tsSkew should equal zero if the denominator equals zero
 			//bowley skew is unreliable if Q2 = Q1 or Q2 = Q3
-			if tsBowleyDen != 0 && tsMid != tsLow && tsMid != tsHigh {
+			if tsBowleyDen >= 10 && tsMid != tsLow && tsMid != tsHigh {
 				tsSkew = float64(tsBowleyNum) / float64(tsBowleyDen)
 			}
 
@@ -150,15 +150,8 @@ func (a *analyzer) start() {
 				tsMadmScore = 0
 			}
 
-			// connection count scoring
-			tsConnDiv := (float64(a.tsMax) - float64(a.tsMin)) / 3600
-			tsConnCountScore := float64(entry.ConnectionCount) / tsConnDiv
-			if tsConnCountScore > 1.0 {
-				tsConnCountScore = 1.0
-			}
-
 			// calculate final ts score
-			tsScore := math.Ceil(((tsSkewScore+tsMadmScore+tsConnCountScore)/3.0)*1000) / 1000
+			tsScore := math.Ceil(((tsSkewScore+tsMadmScore)/2.0)*1000) / 1000
 
 			// calculate duration score
 			duration := math.Ceil((float64(entry.TsList[tsLength]-entry.TsList[0])/(float64(a.tsMax)-float64(a.tsMin)))*1000) / 1000
@@ -188,7 +181,6 @@ func (a *analyzer) start() {
 					"ts.interval_counts": intervalCounts,
 					"ts.dispersion":      tsMadm,
 					"ts.skew":            tsSkew,
-					"ts.conns_score":     tsConnCountScore,
 					"ts.score":           tsScore,
 					"duration_score":     duration,
 					"bucket_divs":        bucketDivs,

--- a/pkg/beaconsni/analyzer.go
+++ b/pkg/beaconsni/analyzer.go
@@ -120,11 +120,11 @@ func (a *analyzer) start() {
 
 			//tsSkew should equal zero if the denominator equals zero
 			//bowley skew is unreliable if Q2 = Q1 or Q2 = Q3
-			if tsBowleyDen != 0 && tsMid != tsLow && tsMid != tsHigh {
+			if tsBowleyDen >= 10 && tsMid != tsLow && tsMid != tsHigh {
 				tsSkew = float64(tsBowleyNum) / float64(tsBowleyDen)
 			}
 
-			if dsBowleyDen != 0 && dsMid != dsLow && dsMid != dsHigh {
+			if dsBowleyDen >= 10 && dsMid != dsLow && dsMid != dsHigh {
 				dsSkew = float64(dsBowleyNum) / float64(dsBowleyDen)
 			}
 
@@ -187,15 +187,8 @@ func (a *analyzer) start() {
 				dsSmallnessScore = 0
 			}
 
-			// connection count scoring
-			tsConnDiv := (float64(a.tsMax) - float64(a.tsMin)) / 3600
-			tsConnCountScore := float64(res.ConnectionCount) / tsConnDiv
-			if tsConnCountScore > 1.0 {
-				tsConnCountScore = 1.0
-			}
-
 			// calculate final ts and ds scores
-			tsScore := math.Ceil(((tsSkewScore+tsMadmScore+tsConnCountScore)/3.0)*1000) / 1000
+			tsScore := math.Ceil(((tsSkewScore+tsMadmScore)/2.0)*1000) / 1000
 			dsScore := math.Ceil(((dsSkewScore+dsMadmScore+dsSmallnessScore)/3.0)*1000) / 1000
 
 			// calculate duration score
@@ -227,7 +220,6 @@ func (a *analyzer) start() {
 					"ts.interval_counts": intervalCounts,
 					"ts.dispersion":      tsMadm,
 					"ts.skew":            tsSkew,
-					"ts.conns_score":     tsConnCountScore,
 					"ts.score":           tsScore,
 					"ds.range":           dsRange,
 					"ds.mode":            dsMode,


### PR DESCRIPTION
## Problem 1
The connection count portion of TS Score portion of beacon scoring is artificially inflating the TS score. Originally, the connection count score was meant to reward beacons going off very frequently, with a perfect score being given to beacons that went off every 10 min or less. Since that led to both malware detection failure and false positives, the formula was adjusted to reward beacons that went off at least once per hour. However, the default thresholds in RITA for the beacon modules are already attempting to weed out analyzing host pairs that don't have at least 20 connections.  Since we want the lat least once per hour in a dataset and gave perfect connection count scores to hosts that had at least 24 connections, this score ended up being redundant and inflated the TS Score unnecessarily. This PR removes the connection count portion of TS Scoring and sets a minimum value for the DefaultConnectionThresh  config values of Beacon, Beacon SNI and Beacon Proxy

## Problem 2

<p align="center">
<img  alt="image" src="https://user-images.githubusercontent.com/6879542/230823490-637b57fb-ec44-4bb7-b436-ea9e919ef3a3.png">
</p> 

Currently we set the Skew portion of the TS Score to 100% if Q2 = Q1 or Q2 = Q3 since the Bowley measure of skewness is unreliable when the left or right quartile are equal to the median. This PR builds on that functionality by adding a check to verify that the interquartile range (Q3– Q1) is at least 10. Since the IQR is the denominator of the skew formula, a very small range can only result in a low score, making it unreliable for this purpose.

<p align="center">
<img width="429" alt="image" src="https://user-images.githubusercontent.com/6879542/230824443-5f46728b-b6ae-46f8-a006-601d3b7d0d59.png">
</p>

## Testing

##### Connection Count removal: 

- C2 implant benchmarks: No change for most, 2 had a score decrease of 3% or less. 
- False positive benchmarks: No change for most, 3 had slight improvement (score decrease) of 2-3% 
 
##### Skew Score Update: 

- C2 implant benchmarks: No change for most, one had a score decrease of 2% and one had an increase of 7%. 
- False positive benchmarks: No change for most, two had slight improvement (score decrease) of 1-2% 
- Below is an example of a C2 benchmark with a small IQR that benefitted from the change:
<p align="center">
<img width="682" alt="image" src="https://user-images.githubusercontent.com/6879542/230826120-328f36e2-41f1-48a6-9225-ba303bfa229c.png">
</p>




