### PR TITLE
Don't filter internal -> internal DNS traffic

### DIFF
--- a/parser/dns.go
+++ b/parser/dns.go
@@ -33,10 +33,8 @@ func parseDNSEntry(parseDNS *parsetypes.DNS, filter filter, retVals ParseResults
 	domain := parseDNS.Query
 
 	// Run domain through filter to filter out certain domains and
-	// filter out internal -> internal and external -> internal traffic
-	//
-	// If an internal DNS resolver is being used, make sure to add the IP address of the resolver to the filter's AlwaysInclude section
-	ignore := (filter.filterDomain(domain) || filter.filterConnPair(srcIP, dstIP))
+	// filter out traffic which is external -> external or external -> internal (if specified in the config file)
+	ignore := (filter.filterDomain(domain) || filter.filterDNSPair(srcIP, dstIP))
 
 	// If domain is not subject to filtering, process
 	if ignore {

--- a/parser/filter.go
+++ b/parser/filter.go
@@ -164,7 +164,7 @@ func (fs *filter) filterSingleIP(IP net.IP) bool {
 // This is determined by the following rules, in order:
 //  1. Not filtered if domain is on the AlwaysInclude list
 //  2. Filtered if domain is on the NeverInclude list
-//  5. Not filtered in all other cases
+//  3. Not filtered in all other cases
 func (fs *filter) filterDomain(domain string) bool {
 	// check if on always included list
 	isDomainIncluded := util.ContainsDomain(fs.alwaysIncludedDomain, domain)

--- a/parser/filter.go
+++ b/parser/filter.go
@@ -88,6 +88,8 @@ func (fs *filter) filterConnPair(srcIP net.IP, dstIP net.IP) bool {
 }
 
 // filterDNSPair returns true if a DNS connection pair is filtered/excluded.
+// DNS is treated specially since we need to capture internal -> internal DNS traffic
+// in order to detect C2 over DNS with an internal resolver.
 // This is determined by the following rules, in order:
 //  1. Not filtered if either IP is on the AlwaysInclude list
 //  2. Filtered if either IP is on the NeverInclude list


### PR DESCRIPTION
This PR creates a new function `filterDNSPair` which is a copy of `filterConnPair` without the internal -> internal traffic filter and changes the DNS parser to use this new function. DNS is treated specially since we need to capture internal -> internal DNS traffic in order to detect C2 over DNS with an internal resolver. 

Currently, the master branch requires users to add their DNS resolver to the AlwaysInclude section of the RITA config file due to the changes in https://github.com/activecm/rita/pull/788. This was not previously required. Additionally, as it stands, there is no way to filter out external -> internal DNS traffic while keeping internal -> internal DNS traffic. 

With this change, users will be able to filter out external -> external and external -> internal DNS traffic. Additionally, they will not be required to add their DNS resolver to the AlwaysInclude list in the filter config.

