### PR TITLE
Only maintain one cid's worth of max scores in the host collection

### DIFF
--- a/pkg/beaconsni/summarizer.go
+++ b/pkg/beaconsni/summarizer.go
@@ -106,7 +106,7 @@ func maxSNIBeaconUpdate(datum data.UniqueIP, beaconSNIColl, hostColl *mgo.Collec
 	hostSelector := datum.BSONKey()
 	hostWithDatEntrySelector := database.MergeBSONMaps(
 		hostSelector,
-		bson.M{"dat": bson.M{"$elemMatch": bson.M{"mbproxy": bson.M{"$exists": true}}}},
+		bson.M{"dat": bson.M{"$elemMatch": bson.M{"mbsni": bson.M{"$exists": true}}}},
 	)
 
 	nExistingEntries, err := hostColl.Find(hostWithDatEntrySelector).Count()

--- a/pkg/beaconsni/summarizer.go
+++ b/pkg/beaconsni/summarizer.go
@@ -97,7 +97,7 @@ func maxSNIBeaconUpdate(datum data.UniqueIP, beaconSNIColl, hostColl *mgo.Collec
 		Score float64 `bson:"score"`
 	}
 
-	mbdstQuery := maxSNIBeaconPipeline(datum, chunk)
+	mbdstQuery := maxSNIBeaconPipeline(datum)
 	err := beaconSNIColl.Pipe(mbdstQuery).One(&maxBeaconSNI)
 	if err != nil {
 		return nil, nil, err
@@ -106,7 +106,7 @@ func maxSNIBeaconUpdate(datum data.UniqueIP, beaconSNIColl, hostColl *mgo.Collec
 	hostSelector := datum.BSONKey()
 	hostWithDatEntrySelector := database.MergeBSONMaps(
 		hostSelector,
-		bson.M{"dat.mbsni": maxBeaconSNI.Fqdn},
+		bson.M{"dat": bson.M{"$elemMatch": bson.M{"mbproxy": bson.M{"$exists": true}}}},
 	)
 
 	nExistingEntries, err := hostColl.Find(hostWithDatEntrySelector).Count()
@@ -115,10 +115,9 @@ func maxSNIBeaconUpdate(datum data.UniqueIP, beaconSNIColl, hostColl *mgo.Collec
 	}
 
 	if nExistingEntries > 0 {
-		// just need to update the cid and score if there is an
-		// an existing record
 		updateQuery := bson.M{
 			"$set": bson.M{
+				"dat.$.mbsni":                maxBeaconSNI.Fqdn,
 				"dat.$.max_beacon_sni_score": maxBeaconSNI.Score,
 				"dat.$.cid":                  chunk,
 			},
@@ -140,12 +139,11 @@ func maxSNIBeaconUpdate(datum data.UniqueIP, beaconSNIColl, hostColl *mgo.Collec
 	return hostSelector, insertQuery, nil
 }
 
-func maxSNIBeaconPipeline(host data.UniqueIP, chunk int) []bson.M {
+func maxSNIBeaconPipeline(host data.UniqueIP) []bson.M {
 	return []bson.M{
 		{"$match": bson.M{
 			"src":              host.IP,
 			"src_network_uuid": host.NetworkUUID,
-			"cid":              chunk,
 		}},
 		// drop unnecessary data
 		{"$project": bson.M{

--- a/pkg/uconn/summarizer.go
+++ b/pkg/uconn/summarizer.go
@@ -196,7 +196,7 @@ func maxTotalDurationPipeline(host data.UniqueIP) []bson.M {
 			"dat.cid":  1,
 			"dat.tdur": 1,
 		}},
-		// for each peer, combine the records that match the current chunk
+		// for each peer, combine the records
 		{"$project": bson.M{
 			"peer": 1,
 			"tdur": bson.M{"$sum": "$dat.tdur"},

--- a/pkg/uconn/summarizer.go
+++ b/pkg/uconn/summarizer.go
@@ -193,7 +193,6 @@ func maxTotalDurationPipeline(host data.UniqueIP) []bson.M {
 					},
 				},
 			},
-			"dat.cid":  1,
 			"dat.tdur": 1,
 		}},
 		// for each peer, combine the records


### PR DESCRIPTION
This PR changes the summarize / aggregation phase of the IP beacons, proxy beacons, SNI beacons, and unique connection analyses to perform a total roll-up of the currently imported data for each host rather than a roll-up for the data that was just imported. This allows us to store a single copy of the roll-ups in the host collection for each internal host instead of a record per chunked import. In turn, we no longer have to worry about old roll-ups falling out of sync with new data. Closes #800

Testing:
I've tested this PR against the logs linked in #800 and ensured that the problem is fixed there. I am currently testing to ensure that we don't have any regressions on other datasets.