### PR TITLE
Add step to manual install instrucions to run chmod 777

### DIFF
--- a/docs/Manual Installation.md
+++ b/docs/Manual Installation.md
@@ -49,6 +49,7 @@ RITA requires a few directories to be created for it to function correctly.
 
 1. ```sudo mkdir /etc/rita && sudo chmod 755 /etc/rita```
 1. ```sudo mkdir -p /var/lib/rita/logs && sudo chmod -R 755 /var/lib/rita```
+1. ```sudo chmod 777 /var/lib/rita/logs```
 
 Copy the config file from your local RITA source code.
 * ```sudo cp etc/rita.yaml /etc/rita/config.yaml && sudo chmod 666 /etc/rita/config.yaml```


### PR DESCRIPTION
### Summary
This PR adds a third step to `Manual Installation.md`'s **Configuring the system** section, prompting the user to use `chmod 777`. Without that, following the instructions resulted in a permissions error.

### Related issue
closes #805 

### Type of change
Docs update

### How has it been tested
- Checked markdown preview to make sure it didn't look weird