### PR TITLE
811 show ip dns fqdns

### DIFF
--- a/commands/show-dns-fqdn-ips.go
+++ b/commands/show-dns-fqdn-ips.go
@@ -30,14 +30,9 @@ func init() {
 }
 
 func showFqdnIps(c *cli.Context) error {
-	db := c.Args().Get(0)
-	if db == "" {
-		return cli.NewExitError("Specify a database", -1)
-	}
-
-	fqdn := c.Args().Get(1)
-	if fqdn == "" {
-		return cli.NewExitError("Specify an FQDN", -1)
+	db, fqdn := c.Args().Get(0), c.Args().Get(1)
+	if db == "" || fqdn == "" {
+		return cli.NewExitError("Specify a database and FQDN", -1)
 	}
 	res := resources.InitResources(getConfigFilePath(c))
 	res.DB.SelectDB(db)

--- a/commands/show-ip-dns-fqdns.go
+++ b/commands/show-ip-dns-fqdns.go
@@ -13,7 +13,7 @@ import (
 func init() {
 	command := cli.Command{
 		Name:      "show-ip-dns-fqdns",
-		Usage:     "Print FQDNs associated with IP via DNS",
+		Usage:     "Print FQDNs associated with IP Address via DNS",
 		ArgsUsage: "<database> <ip address>",
 		Flags: []cli.Flag{
 			ConfigFlag,

--- a/commands/show-ip-dns-fqdns.go
+++ b/commands/show-ip-dns-fqdns.go
@@ -26,15 +26,11 @@ func init() {
 }
 
 func showIpFqdns(c *cli.Context) error {
-	db := c.Args().Get(0)
-	if db == "" {
-		return cli.NewExitError("Specify a database", -1)
+	db, ip := c.Args().Get(0), c.Args().Get(1)
+	if db == "" || ip == "" {
+		return cli.NewExitError("Specify a database and IP address", -1)
 	}
 
-	ip := c.Args().Get(1)
-	if ip == "" {
-		return cli.NewExitError("Specify an IP address", -1)
-	}
 	res := resources.InitResources(getConfigFilePath(c))
 	res.DB.SelectDB(db)
 

--- a/commands/show-ip-dns-fqdns.go
+++ b/commands/show-ip-dns-fqdns.go
@@ -1,6 +1,9 @@
 package commands
 
 import (
+	"fmt"
+
+	"github.com/activecm/rita/pkg/hostname"
 	"github.com/activecm/rita/resources"
 	"github.com/urfave/cli"
 )
@@ -34,6 +37,19 @@ func showIpFqdns(c *cli.Context) error {
 	}
 	res := resources.InitResources(getConfigFilePath(c))
 	res.DB.SelectDB(db)
+
+	fqdnResults, err := hostname.FQDNResults(res, ip)
+
+	if err != nil {
+		res.Log.Error(err)
+		return cli.NewExitError(err, -1)
+	}
+
+	if !(len(fqdnResults) > 0) {
+		return cli.NewExitError("No results were found for "+db, -1)
+	}
+
+	fmt.Println("Hello world!")
 
 	return nil
 }

--- a/commands/show-ip-dns-fqdns.go
+++ b/commands/show-ip-dns-fqdns.go
@@ -65,7 +65,7 @@ func showIpFqdns(c *cli.Context) error {
 func showIpFqdnsHuman(data []*hostname.FQDNResult) error {
 	table := tablewriter.NewWriter(os.Stdout)
 	headerFields := []string{
-		"Resolved FQDNs",
+		"Resolved FQDN",
 	}
 
 	table.SetHeader(headerFields)
@@ -81,7 +81,7 @@ func showIpFqdnsHuman(data []*hostname.FQDNResult) error {
 }
 
 func showIpFqdnsRaw(data []*hostname.FQDNResult) error {
-	fmt.Println("Resolved FQDNs")
+	fmt.Println("Resolved FQDN")
 	for _, d := range data {
 		fmt.Println(d.Hostname)
 	}

--- a/commands/show-ip-dns-fqdns.go
+++ b/commands/show-ip-dns-fqdns.go
@@ -20,13 +20,13 @@ func init() {
 			humanFlag,
 			delimFlag,
 		},
-		Action: showIpFqdns,
+		Action: showIPFqdns,
 	}
 
 	bootstrapCommands(command)
 }
 
-func showIpFqdns(c *cli.Context) error {
+func showIPFqdns(c *cli.Context) error {
 	db, ip := c.Args().Get(0), c.Args().Get(1)
 	if db == "" || ip == "" {
 		return cli.NewExitError("Specify a database and IP address", -1)
@@ -47,14 +47,14 @@ func showIpFqdns(c *cli.Context) error {
 	}
 
 	if c.Bool("human-readable") {
-		err := showIpFqdnsHuman(fqdnResults)
+		err := showIPFqdnsHuman(fqdnResults)
 		if err != nil {
 			return cli.NewExitError(err.Error(), -1)
 		}
 		return nil
 	}
 
-	err = showIpFqdnsRaw(fqdnResults)
+	err = showIPFqdnsRaw(fqdnResults)
 	if err != nil {
 		return cli.NewExitError(err.Error(), -1)
 	}
@@ -62,7 +62,7 @@ func showIpFqdns(c *cli.Context) error {
 	return nil
 }
 
-func showIpFqdnsHuman(data []*hostname.FQDNResult) error {
+func showIPFqdnsHuman(data []*hostname.FQDNResult) error {
 	table := tablewriter.NewWriter(os.Stdout)
 	headerFields := []string{
 		"Resolved FQDN",
@@ -80,7 +80,7 @@ func showIpFqdnsHuman(data []*hostname.FQDNResult) error {
 	return nil
 }
 
-func showIpFqdnsRaw(data []*hostname.FQDNResult) error {
+func showIPFqdnsRaw(data []*hostname.FQDNResult) error {
 	fmt.Println("Resolved FQDN")
 	for _, d := range data {
 		fmt.Println(d.Hostname)

--- a/commands/show-ip-dns-fqdns.go
+++ b/commands/show-ip-dns-fqdns.go
@@ -65,7 +65,7 @@ func showIPFqdns(c *cli.Context) error {
 func showIPFqdnsHuman(data []*hostname.FQDNResult) error {
 	table := tablewriter.NewWriter(os.Stdout)
 	headerFields := []string{
-		"Resolved FQDN",
+		"Queried FQDN",
 	}
 
 	table.SetHeader(headerFields)
@@ -81,7 +81,7 @@ func showIPFqdnsHuman(data []*hostname.FQDNResult) error {
 }
 
 func showIPFqdnsRaw(data []*hostname.FQDNResult) error {
-	fmt.Println("Resolved FQDN")
+	fmt.Println("Queried FQDN")
 	for _, d := range data {
 		fmt.Println(d.Hostname)
 	}

--- a/commands/show-ip-dns-fqdns.go
+++ b/commands/show-ip-dns-fqdns.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/activecm/rita/pkg/hostname"
 	"github.com/activecm/rita/resources"
@@ -17,7 +18,6 @@ func init() {
 			ConfigFlag,
 			humanFlag,
 			delimFlag,
-			netNamesFlag,
 		},
 		Action: showIpFqdns,
 	}
@@ -49,7 +49,27 @@ func showIpFqdns(c *cli.Context) error {
 		return cli.NewExitError("No results were found for "+db, -1)
 	}
 
-	fmt.Println("Hello world!")
+	err = showIpFqdnsDelim(fqdnResults, c.String("delimiter"))
+	if err != nil {
+		return cli.NewExitError(err.Error(), -1)
+	}
 
+	return nil
+}
+
+func showIpFqdnsDelim(data []*hostname.FQDNResult, delim string) error {
+	headerFields := []string{
+		"Resolved FQDNs",
+	}
+
+	// Print the headers and analytic values, separated by a delimiter
+	fmt.Println(strings.Join(headerFields, delim))
+	for _, d := range data {
+		row := []string{
+			d.Hostname,
+		}
+
+		fmt.Println(strings.Join(row, delim))
+	}
 	return nil
 }

--- a/commands/show-ip-dns-fqdns.go
+++ b/commands/show-ip-dns-fqdns.go
@@ -1,0 +1,39 @@
+package commands
+
+import (
+	"github.com/activecm/rita/resources"
+	"github.com/urfave/cli"
+)
+
+func init() {
+	command := cli.Command{
+		Name:      "show-ip-dns-fqdns",
+		Usage:     "Print FQDNs associated with IP via DNS",
+		ArgsUsage: "<database> <ip address>",
+		Flags: []cli.Flag{
+			ConfigFlag,
+			humanFlag,
+			delimFlag,
+			netNamesFlag,
+		},
+		Action: showIpFqdns,
+	}
+
+	bootstrapCommands(command)
+}
+
+func showIpFqdns(c *cli.Context) error {
+	db := c.Args().Get(0)
+	if db == "" {
+		return cli.NewExitError("Specify a database", -1)
+	}
+
+	ip := c.Args().Get(1)
+	if ip == "" {
+		return cli.NewExitError("Specify an IP address", -1)
+	}
+	res := resources.InitResources(getConfigFilePath(c))
+	res.DB.SelectDB(db)
+
+	return nil
+}

--- a/pkg/hostname/repository.go
+++ b/pkg/hostname/repository.go
@@ -17,4 +17,9 @@ type (
 		ResolvedIPs data.UniqueIPSet //Set of resolved UniqueIPs associated with a given hostname
 		ClientIPs   data.UniqueIPSet //Set of DNS Client UniqueIPs which issued queries for a given hostname
 	}
+
+	// FQDN Results for show-ip-dns-fqdns
+	FqdnResult struct {
+		Hostname string `bson:"_id"`
+	}
 )

--- a/pkg/hostname/repository.go
+++ b/pkg/hostname/repository.go
@@ -19,7 +19,7 @@ type (
 	}
 
 	// FQDN Results for show-ip-dns-fqdns
-	FqdnResult struct {
+	FQDNResult struct {
 		Hostname string `bson:"_id"`
 	}
 )

--- a/pkg/hostname/results.go
+++ b/pkg/hostname/results.go
@@ -4,6 +4,7 @@ import (
 	"github.com/activecm/rita/pkg/data"
 	"github.com/activecm/rita/resources"
 	"github.com/globalsign/mgo/bson"
+	"github.com/pkg/hostname"
 )
 
 // IPResults returns the IP addresses the hostname was seen resolving to in the dataset
@@ -40,5 +41,27 @@ func IPResults(res *resources.Resources, hostname string) ([]data.UniqueIP, erro
 
 	var ipResults []data.UniqueIP
 	err := ssn.DB(res.DB.GetSelectedDB()).C(res.Config.T.DNS.HostnamesTable).Pipe(ipsForHostnameQuery).AllowDiskUse().All(&ipResults)
+	return ipResults, err
+}
+
+// FQDNResults returns the FQDNs the IP address was seen resolving to in the dataset
+func FQDNResults(res *resources.Resources, hostname string) ([]hostname.FQDNResult, error) {
+	ssn := res.DB.Session.Copy()
+	defer ssn.Close()
+
+	ipPattern := `^(?:[0-9]{1,3}\.){3}[0-9]{1,3}$|^(?:[A-F0-9]{1,4}:){7}[A-F0-9]{1,4}$
+	`
+	fqdnsForHostnameQuery := []bson.M{
+		{"$match": bson.M{
+			"dat.ips.ip": bson.RegEx{Pattern: ipPattern},
+		}},
+		{"$group": bson.M{
+			"_id": "$host",
+		}},
+		
+	}
+
+	var ipResults []data.UniqueIP
+	err := ssn.DB(res.DB.GetSelectedDB()).C(res.Config.T.DNS.HostnamesTable).Pipe(fqdnsForHostnameQuery).AllowDiskUse().All(&ipResults)
 	return ipResults, err
 }


### PR DESCRIPTION
### Summary
This adds a new command, `show-ip-dns-fqdns <database> <ip address>` which shows the domain names that the IP address was resolved from.

### Related Issue

closes #811

### Testing

__Acquire FQDN(s) to compare RITA command against__

Navigate inside the directory of your zeek logs
Run `zcat dns.* | nice zcutter.py query answers -C` to view a list of FQDNs and IP addresses. Select an IP address to test against.
Run `zcat dns.* | nice zcutter.py query answers -C | grep <regex>| cut -d$'\t' -f1 | sort -u`, replacing <regex> with a regular expression to filter out just the FQDNs associated with the IP address. Here is a regex pattern for an IPv4 address you can use: `'^.*\t.*52\.9\.92\.15.*$'` just replace the digits with the digits of your IPv4 address.
These FQDNs are what you will be checking for when you run the command
(If you want to test for multiple FQDNs, it may be easier to edit your own DNS log. Copy/Paste an entry and change the value of the query column. This should result in additional FQDNs to check for.)

__Test show-dns-fqdn-ips__

Navigate to your RITA dev directory
Make sure you have your dataset imported into RITA and your database is up and running:
Start DB (assuming you are using MongoDB): `sudo systemctl start mongod`
Import dataset: rita import <files/directory to import>
Run `./rita show-ip-dns-fqdns` <database> <fqdn> (e.g. `./rita show-ip-dns-fqdns empire 52.9.92.15`)
You should see the header "Queried FQDN" followed by a list of all FQDNs associated with that IP Address. Compare to the FQDNs you recorded earlier and ensure they match.

__Test flag__

Running the command with -H should show a human-readable view with an ASCII table.

__Test error handling__

Running ./rita show-dns-fqdn-ips should prompt the user to specify a database and IP address
Running ./rita show-dns-fqdn-ips <database> should prompt the user to specify a database and IP address
Running a valid command that yields no results should alert the user that no results were found for that database