### PR TITLE
Adjust show-dns-fqdn-ips to prompt user to supply database and FQDN i…

### DIFF
--- a/commands/show-dns-fqdn-ips.go
+++ b/commands/show-dns-fqdn-ips.go
@@ -30,14 +30,9 @@ func init() {
 }
 
 func showFqdnIps(c *cli.Context) error {
-	db := c.Args().Get(0)
-	if db == "" {
-		return cli.NewExitError("Specify a database", -1)
-	}
-
-	fqdn := c.Args().Get(1)
-	if fqdn == "" {
-		return cli.NewExitError("Specify an FQDN", -1)
+	db, fqdn := c.Args().Get(0), c.Args().Get(1)
+	if db == "" || fqdn == "" {
+		return cli.NewExitError("Specify a database and FQDN", -1)
 	}
 	res := resources.InitResources(getConfigFilePath(c))
 	res.DB.SelectDB(db)


### PR DESCRIPTION
…f supplied with fewer than two arguments

### Summary
This adjusts the logic to `show-dns-fqdn-ips` argument error handling. Now it will prompt the user to enter both a database and an IP address whenever the user enters fewer than two arguments.