### PR TITLE
335 add ipv6 support for single ips

### DIFF
--- a/parser/filter_test.go
+++ b/parser/filter_test.go
@@ -184,7 +184,7 @@ func TestFilterDomain(t *testing.T) {
 
 func TestFilterSingleIP(t *testing.T) {
 
-	fsTest := &filter{
+	fsTest := filter{
 		// purposely omitting internal subnet definition
 		alwaysIncluded: util.ParseSubnets([]string{"10.0.0.1/32", "10.0.0.3/32", "1.1.1.1/32", "1.1.1.3/32"}),
 		neverIncluded:  util.ParseSubnets([]string{"10.0.0.4/32", "10.0.0.3/32", "1.1.1.2/32", "1.1.1.3/32"}),
@@ -207,3 +207,8 @@ func TestFilterSingleIP(t *testing.T) {
 		assert.Equal(t, test.out, output, test.msg)
 	}
 }
+
+// In alwaysIncluded, just leave it as an empty slice, replace
+// util.ParseSubnets with []*net.IPNet
+// In neverIncluded, include the IPv6 address without CIDR.
+// Test case will be modeled after the "never" test case

--- a/parser/filter_test.go
+++ b/parser/filter_test.go
@@ -208,7 +208,21 @@ func TestFilterSingleIP(t *testing.T) {
 	}
 }
 
-// In alwaysIncluded, just leave it as an empty slice, replace
-// util.ParseSubnets with []*net.IPNet
-// In neverIncluded, include the IPv6 address without CIDR.
-// Test case will be modeled after the "never" test case
+func TestFilterSingleIPv6(t *testing.T) {
+	fsTest := filter{
+		// purposely omitting internal subnet definition
+		alwaysIncluded: []*net.IPNet{},
+		neverIncluded: util.ParseSubnets([]string{"::1"}),
+	}
+
+	never:= "::1"
+
+	testCases := []testCaseSingleIP{
+		{never, true, "NeverInclude IP should be filtered"},
+	}
+
+	for _, test := range testCases {
+		output := fsTest.filterSingleIP(net.ParseIP(test.ip))
+		assert.Equal(t, test.out, output, test.msg)
+	}
+}

--- a/util/ip.go
+++ b/util/ip.go
@@ -34,7 +34,7 @@ func ParseSubnets(subnets []string) []*net.IPNet {
 		// Try to parse out CIDR range
 		_, block, err := net.ParseCIDR(entry)
 
-		// If there was an error, check if entry was an IP, not a range
+		// If there was an error, check if entry was an IP
 		if err != nil {
 			ipAddr := net.ParseIP(entry)
 			if ipAddr == nil {
@@ -45,9 +45,9 @@ func ParseSubnets(subnets []string) []*net.IPNet {
 			// Check if it's an IPv4 or IPv6 address and append the appropriate subnet mask
 			var subnetMask string
 			if ipAddr.To4() != nil {
-				subnetMask = "/32" // IPv4
+				subnetMask = "/32"
 			} else {
-				subnetMask = "/128" // IPv6
+				subnetMask = "/128"
 			}
 
 			// Append the subnet mask and parse as a CIDR range


### PR DESCRIPTION
### Summary
This resolves the issue of `ParseSubnets` not differentiating between IPv4 and IPv6 addresses before appending a subnet mask. It also adds `TestFilterSingleIPv6` to test the new functionality.

### Related Issue

closes #335

### Testing

`cd` into `parser` and run:
```
go test
```