### PR TITLE
Updated docker documentation and db container name to avoid confusion with db volume

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 
 services:
-  db:
+  mongo-db:
     image: mongo:4.2
     volumes:
       - db:/data/db/
@@ -10,7 +10,7 @@ services:
     image: quay.io/activecm/rita:${VERSION:-latest}
     build: .
     depends_on:
-      - db
+      - mongo-db
     volumes:
       - ${CONFIG:?You must provide a path to your CONFIG}:/etc/rita/config.yaml:ro
       - ${LOGS:?You must provide a path to your LOGS}:/logs:ro

--- a/docs/Docker Usage.md
+++ b/docs/Docker Usage.md
@@ -21,7 +21,7 @@ sudo docker build -t quay.io/activecm/rita .
 
 ## Running RITA with Docker Compose
 
-You will need a config file where you have [put in your `InternalSubnets`](../Readme.md#configuration-file).
+You will need a [config file](rita/etc/rita_docker.yaml) (make sure to use rita_docker.yaml instead of rita.yaml) where you have [put in your `InternalSubnets`](../Readme.md#configuration-file).
 You will also need the path to your Zeek log files.
 
 ```

--- a/etc/rita_docker.yaml
+++ b/etc/rita_docker.yaml
@@ -1,7 +1,7 @@
 # This section configures the connection to the MongoDB server and the database name to use
 MongoDB:
   # See https://docs.mongodb.com/manual/reference/connection-string/
-  ConnectionString: mongodb://db:27017
+  ConnectionString: mongodb://mongo-db:27017
   # Example with authentication. Be sure to change the AuthenticationMechanism as well.
   # ConnectionString: mongodb://username:password@localhost:27017
 


### PR DESCRIPTION
Related to issue #807, updated docker compose usage documentation to explicitly mention that users should use "rita_docker.yaml" and not "rita.yaml" as the template. Additionally, renamed the mongodb container name from "db" to mongo-db to avoid confusion and overlap with the db volume also used in the docker-compose.yml.