### PR TITLE
Install docker-zeek by default when installing rita.  FOR REVIEW AND DISCUSSION

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,4 +32,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-            files: installer/rita-${{ github.ref_name }}.tar.gz
+            files: |
+              installer/rita-${{ github.ref_name }}.tar.gz
+              install-rita-zeek-here.sh

--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@
 /installer/stage
 /installer/rita-*.tar.gz
 /installer/rita-*
+/installer/install-rita-zeek-here.sh
 !/installer/*.md
 
 # only commit .env, .env.production, and test.env files

--- a/installer/generate_installer.sh
+++ b/installer/generate_installer.sh
@@ -60,6 +60,7 @@ cp ../default_config.hjson "$INSTALL_ETC"/config.hjson
 # copy over installed files to /opt
 cp ../rita.sh "$INSTALL_OPT"/rita.sh
 curl --fail --silent --show-error -o "$INSTALL_OPT"/zeek https://raw.githubusercontent.com/activecm/docker-zeek/master/zeek
+chmod +x "$INSTALL_OPT"/zeek
 cp ../.env.production "$INSTALL_OPT"/.env
 cp ../docker-compose.prod.yml "$INSTALL_OPT"/docker-compose.yml
 cp ../LICENSE "$INSTALL_OPT"/LICENSE

--- a/installer/generate_installer.sh
+++ b/installer/generate_installer.sh
@@ -67,19 +67,23 @@ cp ../LICENSE "$INSTALL_OPT"/LICENSE
 cp ../README.md "$INSTALL_OPT"/README
 
 
+cp ./install-rita-zeek-here-tmp.sh install-rita-zeek-here.sh
 
 # update version variables for files that need them
 if [ "$(uname)" == "Darwin" ]; then
+    sed -i'.bak' "s/RITA_REPLACE_ME/${VERSION}/g" "install-rita-zeek-here.sh" 
     sed -i'.bak' "s/REPLACE_ME/${VERSION}/g" "$BASE_DIR/install_rita.yml" 
     sed -i'.bak' "s/REPLACE_ME/${ZEEK_VERSION}/g" "$BASE_DIR/install_zeek.yml" 
     sed -i'.bak' "s/REPLACE_ME/${VERSION}/g" "$BASE_DIR/install_rita.sh"
     sed -i'.bak' "s#ghcr.io/activecm/rita:latest#ghcr.io/activecm/rita:${VERSION}#g" "$INSTALL_OPT/docker-compose.yml"
-
+    
+    rm "install-rita-zeek-here.sh.bak"
     rm "$BASE_DIR/install_rita.yml.bak"
     rm "$BASE_DIR/install_zeek.yml.bak"
     rm "$BASE_DIR/install_rita.sh.bak"
     rm "$INSTALL_OPT/docker-compose.yml.bak"
 else 
+    sed -i  "s/RITA_REPLACE_ME/${VERSION}/g" ./install-rita-zeek-here.sh
     sed -i  "s/REPLACE_ME/${VERSION}/g" "$BASE_DIR/install_rita.yml" 
     sed -i  "s/REPLACE_ME/${ZEEK_VERSION}/g" "$BASE_DIR/install_zeek.yml" 
     sed -i  "s/REPLACE_ME/${VERSION}/g" "$BASE_DIR/install_rita.sh"

--- a/installer/generate_installer.sh
+++ b/installer/generate_installer.sh
@@ -5,6 +5,8 @@ set -e
 # and copies files that must be in the installer into the stage folder.
 # Once all directories are placed in stage, it is compressed and stage is deleted
 
+ZEEK_VERSION=6.2.1
+
 # get RITA version from git
 VERSION=$(git describe --always --abbrev=0 --tags)
 echo "Generating installer for RITA $VERSION..."
@@ -38,6 +40,7 @@ mkdir "$ANSIBLE_FILES"/etc
 
 
 # copy files in base dir
+cp ./install_scripts/install_zeek.yml "$BASE_DIR"
 cp ./install_scripts/install_rita.yml "$BASE_DIR"
 cp ./install_scripts/install_rita.sh "$BASE_DIR" # entrypoint
 
@@ -56,6 +59,7 @@ cp ../default_config.hjson "$INSTALL_ETC"/config.hjson
 
 # copy over installed files to /opt
 cp ../rita.sh "$INSTALL_OPT"/rita.sh
+curl --fail --silent --show-error -o "$INSTALL_OPT"/zeek https://raw.githubusercontent.com/activecm/docker-zeek/master/zeek
 cp ../.env.production "$INSTALL_OPT"/.env
 cp ../docker-compose.prod.yml "$INSTALL_OPT"/docker-compose.yml
 cp ../LICENSE "$INSTALL_OPT"/LICENSE
@@ -65,15 +69,18 @@ cp ../README.md "$INSTALL_OPT"/README
 
 # update version variables for files that need them
 if [ "$(uname)" == "Darwin" ]; then
-    sed -i'.bak' "s/REPLACE_ME/${VERSION}/g" "$BASE_DIR/install_rita.yml" # WAS $ANSIBLE_PLAYBOOKS
+    sed -i'.bak' "s/REPLACE_ME/${VERSION}/g" "$BASE_DIR/install_rita.yml" 
+    sed -i'.bak' "s/REPLACE_ME/${ZEEK_VERSION}/g" "$BASE_DIR/install_zeek.yml" 
     sed -i'.bak' "s/REPLACE_ME/${VERSION}/g" "$BASE_DIR/install_rita.sh"
     sed -i'.bak' "s#ghcr.io/activecm/rita:latest#ghcr.io/activecm/rita:${VERSION}#g" "$INSTALL_OPT/docker-compose.yml"
 
     rm "$BASE_DIR/install_rita.yml.bak"
+    rm "$BASE_DIR/install_zeek.yml.bak"
     rm "$BASE_DIR/install_rita.sh.bak"
     rm "$INSTALL_OPT/docker-compose.yml.bak"
 else 
-    sed -i  "s/REPLACE_ME/${VERSION}/g" "$BASE_DIR/install_rita.yml" # WAS $ANSIBLE_PLAYBOOKS
+    sed -i  "s/REPLACE_ME/${VERSION}/g" "$BASE_DIR/install_rita.yml" 
+    sed -i  "s/REPLACE_ME/${ZEEK_VERSION}/g" "$BASE_DIR/install_zeek.yml" 
     sed -i  "s/REPLACE_ME/${VERSION}/g" "$BASE_DIR/install_rita.sh"
     sed -i  "s#ghcr.io/activecm/rita:latest#ghcr.io/activecm/rita:${VERSION}#g" "$INSTALL_OPT/docker-compose.yml"
 fi
@@ -83,11 +90,9 @@ fi
 
 
 # ./build_image.sh
-# cp "./rita-$VERSION-image.tar" "$ANSIBLE_FILES" # was $INSTALL_OPT
-# rm "./rita-$VERSION-image.tar"
+
 
 # create tar
-# TODO the inner folder is named stage, should be rita-$VERSION
 tar -czf "rita-$VERSION.tar.gz" "$BASE_DIR"
 
 # delete staging folder

--- a/installer/install-rita-zeek-here-tmp.sh
+++ b/installer/install-rita-zeek-here-tmp.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+#This installs docker, rita, and zeek on the current system.
+#V0.1.4
+
+#Run one of the following 3 command lines:
+#	curl -A Mozilla -fsSL https://thunt-level1.s3.amazonaws.com/install-rita-zeek-here.sh | sudo bash -
+#	wget -U Mozilla -q -O - https://thunt-level1.s3.amazonaws.com/install-rita-zeek-here.sh | sudo bash -
+#or download the above file and run:
+#	sudo bash install-rita-zeek-here.sh
+
+export RITA_VERSION="RITA_REPLACE_ME"
+# export rver='5.0.6'
+export zeek_release='latest'
+export PATH="$PATH:/usr/local/bin/"
+echo 'export PATH=$PATH:/usr/local/bin/' | sudo tee -a /etc/profile.d/localpath.sh
+
+if [ "$EUID" -ne 0 ]; then
+	Sudo="/usr/bin/sudo "
+fi
+
+$Sudo mkdir -p /usr/local/bin/
+
+echo "==== Installing rita $RITA_VERSION ====" >&2
+cd
+wget https://github.com/activecm/rita/releases/download/v${RITA_VERSION}/rita-v${RITA_VERSION}.tar.gz
+tar -xzvf rita-v${RITA_VERSION}.tar.gz
+cd rita-v${RITA_VERSION}-installer
+./install_rita.sh localhost </dev/stderr
+rita help </dev/stderr
+
+echo "==== Installing zeek $zeek_release ====" >&2
+$Sudo wget -O /usr/local/bin/zeek https://raw.githubusercontent.com/activecm/docker-zeek/master/zeek
+$Sudo chmod +x /usr/local/bin/zeek
+/usr/local/bin/zeek pull </dev/stderr
+sleep 2
+/usr/local/bin/zeek stop </dev/stderr
+echo "Please run 'zeek start' if you want to start zeek running in the background." >&2
+echo 'If your system has trouble locating either zeek or rita we recommend logging out and logging back in.' >&2

--- a/installer/install_scripts/install_rita.sh
+++ b/installer/install_scripts/install_rita.sh
@@ -1,16 +1,26 @@
 #!/bin/bash
 
 RITA_VERSION="REPLACE_ME"
+_INSTALL_ZEEK=true
 
 set -e 
 
+if [ "z$1" = "z--disable-zeek" ]; then
+	_INSTALL_ZEEK=false
+	shift
+fi
 if [ -n "$1" ]; then
 	install_target="$1"
+	shift
 else
 	echo "Please add the name of the system on which you want rita installed as a command line option.  If you want to install rita on this computer, use    127.0.0.1    ." >&2
 	echo "The final command will look like:" >&2
 	echo "$0 the_computer_name_or_ip_on_which_to_install_rita" >&2
 	exit 1
+fi
+if [ "z$1" = "z--disable-zeek" ]; then
+	_INSTALL_ZEEK=false
+	shift
 fi
 
 # change working directory to directory of this script
@@ -24,21 +34,27 @@ source ./scripts/helper.sh
 
 status "Installing rita via ansible on $install_target"		#================
 if [ "$install_target" = "localhost" -o "$install_target" = "127.0.0.1" -o "$install_target" = "::1" ]; then
-        if [ "$(uname)" == "Darwin" ]; then
+        if [ "$(uname)" = "Darwin" ]; then
             # TODO support macOS install target
             echo "${YELLOW}Installing RITA via Ansible on the local system is not yet supported on MacOS.${NORMAL}"
             exit 1
         fi
-    status "If asked for a 'BECOME password', that is your non-root sudo password on this machine ."
-    ansible-playbook --connection=local -K -i "127.0.0.1," -e "install_hosts=127.0.0.1," install_rita.yml
+	status "If asked for a 'BECOME password', that is your non-root sudo password on this machine ."
+	ansible-playbook --connection=local -K -i "127.0.0.1," -e "install_hosts=127.0.0.1," install_rita.yml
+	if [ "$_INSTALL_ZEEK" = 'true' ]; then
+		ansible-playbook --connection=local -K -i "127.0.0.1," -e "install_hosts=127.0.0.1," install_zeek.yml
+	fi
 else
-    status "Setting up future ssh connections to $install_target .  You may be asked to provide your ssh password to $install_target ."		#================
-    ./scripts/sshprep "$install_target"
-    status "If asked for a 'BECOME password', that is your non-root sudo password on $install_target ."
-    ansible-playbook -K -i "${install_target}," -e "install_hosts=${install_target}," install_rita.yml
+	status "Setting up future ssh connections to $install_target .  You may be asked to provide your ssh password to $install_target ."		#================
+	./scripts/sshprep "$install_target"
+	status "If asked for a 'BECOME password', that is your non-root sudo password on $install_target ."
+	ansible-playbook -K -i "${install_target}," -e "install_hosts=${install_target}," install_rita.yml
+	if [ "$_INSTALL_ZEEK" = 'true' ]; then
+		ansible-playbook -K -i "${install_target}," -e "install_hosts=${install_target}," install_zeek.yml
+	fi
 fi
 
-    # ansible-playbook -i ../digitalocean_inventory.py -e "install_hosts=all" install_rita.yml
+	# ansible-playbook -i ../digitalocean_inventory.py -e "install_hosts=all" install_rita.yml
 
 echo \
 "

--- a/installer/install_scripts/install_zeek.yml
+++ b/installer/install_scripts/install_zeek.yml
@@ -1,0 +1,633 @@
+---
+#ansible install playbook for docker-zeek.
+#Version: 202407220000
+#sample runs:
+#	Run this, with a comma separated list of hostnames from the above file with a comma at the end of the list:
+#
+#	ansible-playbook -C -K -i "ro810,ub2404," -e "install_hosts=ro810,ub2404," ~/.ansible/playbooks/install_zeek.yml | grep -v '^skipping: '	#-C (no changes) means do a dry run
+#	ansible-playbook -K -i "ro810,ub2404," -e "install_hosts=ro810,ub2404," ~/.ansible/playbooks/install_zeek.yml | grep -v '^skipping: '
+
+#Many thanks to but-i-am-dominator for his help with this playbook.
+
+
+- name: "Zeek Install: Zeek installer and system prep and checks."
+  hosts: "{{  install_hosts  }}"
+  #hosts: "{{  install_hosts | default('all')  }}"						#Not a good idea to fall back on every host in your ansible hosts file.
+  become: true
+
+  vars:
+    zeek_version: "REPLACE_ME"								
+    zeek_container_image: "activecm/zeek:{{  zeek_version }}"
+    clickhouse_container_image: clickhouse/clickhouse-server:latest
+    ansible_python_interpreter: /bin/python3							# Centos 7 defaults to using python2, so we force python 3.  This change does not break any other distros
+
+#Early tasks needed to support the rest of the install
+  pre_tasks:
+#Known distribution?
+    - name: "Zeek Install: Checking Linux distribution."
+      ansible.builtin.fail:
+        msg: "Distribution name: {{  ansible_distribution  }} does not appear to be recognized - please contact ACM"
+      when: ( ansible_distribution != 'AlmaLinux' and ansible_distribution != 'CentOS' and ansible_distribution != 'Fedora' and ansible_distribution != 'OracleLinux' and ansible_distribution != 'Pop!_OS' and ansible_distribution != 'Rocky' and ansible_distribution != 'Debian' and ansible_distribution != 'Ubuntu' and ansible_distribution != 'Kali' and ansible_distribution != 'Zorin OS' )
+      # and ansible_distribution != 'RedHat'
+      tags:
+        - linux
+
+    - name: "Zeek Install: Checking Linux distribution version."
+      ansible.builtin.fail:
+        msg: "Warning: Linux distribution {{  ansible_distribution  }} {{  ansible_distribution_major_version  }} may not have been tested - please contact ACM and report whether the install worked or not"
+      when: ( ( ansible_distribution == 'AlmaLinux' and (ansible_distribution_major_version != '9') ) or ( ansible_distribution == 'CentOS' and (ansible_distribution_major_version != '7' and ansible_distribution_major_version != '9') ) or ( ansible_distribution == 'Fedora' and (ansible_distribution_major_version != '40') ) or ( ansible_distribution == 'OracleLinux' and (ansible_distribution_major_version != '9') ) or ( ansible_distribution == 'Pop!_OS' and (ansible_distribution_major_version != '22') ) or ( ansible_distribution == 'Rocky' and (ansible_distribution_major_version != '8' and ansible_distribution_major_version != '9') ) or ( ansible_distribution == 'Debian' and (ansible_distribution_major_version != '12') ) or ( ansible_distribution == 'Kali' and (ansible_distribution_major_version != '2024') )  or ( ansible_distribution == 'Ubuntu' and (ansible_distribution_major_version != '20' and ansible_distribution_major_version != '22' and ansible_distribution_major_version != '24') ) or ( ansible_distribution == 'Zorin OS' and (ansible_distribution_major_version != '16') ) )
+      #or ( ansible_distribution != 'RedHat' and (ansible_distribution_major_version == '9') ) 
+      ignore_errors: True		#We print a warning but do not abort if this is an unknown combination of distribution and major version.
+      tags:
+        - linux
+
+#CPU Architecture
+    - name: "Zeek Install: Check system architecture."
+      ansible.builtin.fail:
+        msg: "Unsupported CPU architecture: {{  ansible_architecture  }}"
+      when: ( ansible_architecture != "x86_64" ) 	#and ansible_architecture != "aarch64" ) # "aarch64" for pi.  #pi0w is armv6l.  i386.  amd64?
+
+#Selinux checks
+    - name: "Zeek Install: /sys/fs/selinux/enforce  exists."
+      stat:
+        path: "/sys/fs/selinux/enforce"
+      check_mode: true
+      changed_when: false
+      register: selinuxenforce_check
+      tags:
+        - linux
+
+    - name: "Zeek Install: sys filesystem check for selinux."
+      lineinfile:
+        path: /sys/fs/selinux/enforce
+        regexp: '^1'
+        line: 0
+        create: false
+        unsafe_writes: true									#Needed because the original file in the sys filesystem and Ansible's tmp directory are on different filesystems.
+        state: present
+      #check_mode: yes
+      changed_when: false
+      #register: enforce_check
+      when: selinuxenforce_check.stat.exists
+      tags:
+        - linux
+
+#Add tools needed by later stages
+    # Provides "needs-restarting" for ansible's ability to manage rebooting after patching
+    - name: "Zeek Install: Check for yum-utils before proceeding."
+      command: rpm -qa | grep yum-utils
+      check_mode: true
+      changed_when: false
+      register: package_check
+      when: ( ansible_distribution == 'AlmaLinux' or ansible_distribution == 'CentOS' or ansible_distribution == 'Fedora' or ansible_distribution == 'OracleLinux' or ansible_distribution == 'RedHat' or ansible_distribution == 'Rocky' )
+      tags:
+        - packages
+        - linux
+        - linuxrpm
+
+    - name: "Zeek Install: Install yum-utils if not found."
+      package:
+        name: yum-utils
+        state: latest
+      when: ( ansible_distribution == 'AlmaLinux' or ansible_distribution == 'CentOS' or ansible_distribution == 'Fedora' or ansible_distribution == 'OracleLinux' or ansible_distribution == 'RedHat' or ansible_distribution == 'Rocky' ) and '"yum-utils" not in package_check'
+      tags:
+        - packages
+        - linux
+        - linuxrpm
+
+    # Install aptitude, preferred by ansible for package management on Debian/Ubuntu
+    - name: "Zeek Install: Install aptitude on debian-based system."
+      apt:
+        name: aptitude
+        state: latest
+        update_cache: true
+        cache_valid_time: 3600
+      when: ( ansible_distribution == 'Debian' or ansible_distribution == 'Pop!_OS' or ansible_distribution == 'Ubuntu' or ansible_distribution == 'Zorin OS' )		#While Kali is based on Debian, it does not include the aptitude package.
+      tags:
+        - packages
+        - linux
+        - linuxdeb
+
+
+  tasks:
+# Make sure all rpm packages up to date, add packages
+    - name: "Zeek Install: Patch and install packages on rpm-based servers."
+      block:
+        - name: "Zeek Install: Patch all rpm-based servers."
+          yum:											#We use the "yum" module insteead of dnf to support rpm distros that only have yum
+            name: "*"
+            state: latest
+            skip_broken: yes
+            update_cache: yes
+          tags:
+            - packages
+            - linux
+            - linuxrpm
+
+        - name: "Zeek Install: Install rpm packages on rpm-based distributions."
+          yum:
+            name:
+              - nano
+              - nmap-ncat
+              - dnf-plugins-core								#Provides config-manager binary on Fedora
+              - wget
+              - lshw										#For user troubleshooting
+              - net-tools									#For user troubleshooting
+            state: latest
+            update_cache: true
+          tags:
+            - packages
+            - linux
+            - linuxrpm
+      when: ( ansible_distribution == 'AlmaLinux' or ansible_distribution == 'CentOS' or ansible_distribution == 'Fedora' or ansible_distribution == 'OracleLinux' or ansible_distribution == 'RedHat' or ansible_distribution == 'Rocky' )
+
+    - name: "Zeek Install: Install pip on Centos/Fedora."
+      yum:
+        name:
+          - python3-pip
+        state: latest
+        update_cache: true
+      tags:
+        - packages
+        - linux
+        - linuxrpm
+      when: ( ansible_distribution == 'AlmaLinux' or ansible_distribution == 'CentOS' or ansible_distribution == 'Fedora' or ansible_distribution == 'RedHat' or ansible_distribution == 'Rocky' )
+      #  or ansible_distribution == 'OracleLinux'		#Note: OracleLinux, and therefore SecurityOnion too, do not include pip3.  Disabled.
+
+    - name: "Zeek Install: Patch and install packages on debian-based servers."
+      block:
+        - name: "Zeek Install: Patch all debian-based servers."
+          apt:
+            name: "*"
+            state: latest
+            update_cache: yes
+            cache_valid_time: 3600
+          tags:
+            - packages
+            - linux
+            - linuxdeb
+
+        - name: "Zeek Install: Install apt packages on deb-based distributions."
+          apt:
+            pkg:
+              - nano
+              #Following are to support docker
+              - apt-transport-https
+              - ca-certificates
+              - curl
+              - python3-pip
+              - python3-setuptools
+              - wget
+              #Following is for user troubleshooting
+              - net-tools
+            state: latest
+            update_cache: true
+            cache_valid_time: 3600
+          tags:
+            - packages
+            - linux
+            - linuxdeb
+      when: ( ansible_distribution == 'Debian' or ansible_distribution == 'Kali' or ansible_distribution == 'Pop!_OS' or ansible_distribution == 'Ubuntu' or ansible_distribution == 'Zorin OS' )
+
+
+    - name: "Zeek Install: Install packages on Debian and Ubuntu."
+      apt:
+        pkg:
+          - ncat				#"ncat" is nmap's netcat on Ubuntu and Debian, listd but not available on Kali
+          - software-properties-common
+          - virtualenv
+          - lshw				#listed, but somehow not available on Kali
+        state: latest
+        update_cache: true
+        cache_valid_time: 3600
+      tags:
+        - packages
+        - linux
+        - linuxdeb
+      when: ( ansible_distribution == 'Debian' or ansible_distribution == 'Pop!_OS' or ansible_distribution == 'Ubuntu' or ansible_distribution == 'Zorin OS' )
+
+    - name: "Zeek Install: Install packages on Kali."
+      apt:
+        pkg:
+          - netcat-traditional
+          - python3-virtualenv
+        state: latest
+        update_cache: true
+        cache_valid_time: 3600
+      tags:
+        - packages
+        - linux
+        - linuxdeb
+      when: ( ansible_distribution == 'Kali' )
+
+
+
+#Add repositories
+    - name: "Zeek Install: Add Docker Ubuntu GPG apt key."
+      apt_key:
+        url: https://download.docker.com/linux/ubuntu/gpg
+        state: present
+      when: ( ansible_distribution == 'Ubuntu' )
+      tags:
+        - packages
+        - linux
+        - linuxdeb
+
+    - name: "Zeek Install: Add Docker Debian GPG apt key."
+      apt_key:
+        url: https://download.docker.com/linux/debian/gpg
+        state: present
+      when: ( ansible_distribution == 'Debian' or ansible_distribution == 'Kali' or ansible_distribution == 'Pop!_OS' or ansible_distribution == 'Zorin OS' )
+      tags:
+        - packages
+        - linux
+        - linuxdeb
+
+    - name: "Zeek Install: Add Docker Repository to Ubuntu or Debian."
+      apt_repository:
+        repo: deb https://download.docker.com/linux/{{  ansible_distribution|lower  }} {{  ansible_distribution_release  }} stable
+        state: present
+      when: ( ansible_distribution == 'Ubuntu' or ansible_distribution == 'Debian' )
+      tags:
+        - packages
+        - linux
+        - linuxdeb
+
+    - name: "Zeek Install: Add Docker Repository to Kali."
+      apt_repository:
+        repo: deb https://download.docker.com/linux/debian bookworm stable
+        state: present
+      when: ( ansible_distribution == 'Kali' and ansible_distribution_major_version == '2024' )
+      #Debian bookworm appears to be the right one to use according to https://www.kali.org/docs/containers/installing-docker-on-kali/
+      tags:
+        - packages
+        - linux
+        - linuxdeb
+
+    - name: "Zeek Install: Add Docker Repository to PopOS."
+      apt_repository:
+        repo: deb https://download.docker.com/linux/ubuntu jammy stable
+        state: present
+      when: ( ansible_distribution == 'Pop!_OS' and ansible_distribution_major_version == '22' )
+      #Ubuntu jammy appears to be the right one to use.
+      tags:
+        - packages
+        - linux
+        - linuxdeb
+
+    - name: "Zeek Install: Add Docker Repository to Zorin."
+      apt_repository:
+        repo: deb https://download.docker.com/linux/ubuntu focal stable
+        state: present
+      when: ( ansible_distribution == 'Zorin OS' and ansible_distribution_major_version == '16' )
+      #Ubuntu focal appears to be the right one to use.
+      tags:
+        - packages
+        - linux
+        - linuxdeb
+
+    - name: "Zeek Install: Add Docker repository to Fedora distributions."
+      yum_repository:
+        name: docker-ce
+        description: Docker package repository
+        gpgkey: https://download.docker.com/linux/fedora/gpg
+        baseurl: https://download.docker.com/linux/fedora/$releasever/$basearch/stable/
+        state: present
+        enabled: true
+      when: ( ansible_distribution == 'Fedora' )	# and ansible_distribution_major_version == '40' )
+      tags:
+        - packages
+        - linux
+        - linuxrpm
+
+    - name: "Zeek Install: Add Docker Repository to AlmaLinux/Centos/OracleLinux/Rocky distributions."
+      #shell: yum-config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo
+      yum_repository:
+        name: docker-ce
+        description: Docker package repository
+        gpgkey: https://download.docker.com/linux/centos/gpg
+        baseurl: https://download.docker.com/linux/centos/$releasever/$basearch/stable/
+        state: present
+        enabled: true
+      when: ( ansible_distribution == 'AlmaLinux' or ansible_distribution == 'CentOS' or ansible_distribution == 'OracleLinux' or ansible_distribution == 'Rocky' )
+      tags:
+        - packages
+        - linux
+        - linuxrpm
+
+    - name: "Zeek Install: Add Docker Repository to RHEL distribution."
+      yum_repository:
+        name: docker-ce
+        description: Docker package repository
+        gpgkey: https://download.docker.com/linux/rhel/gpg
+        baseurl: https://download.docker.com/linux/rhel/$releasever/$basearch/stable/
+        state: present
+        enabled: true
+      when: ( ansible_distribution == 'RedHat' )
+      tags:
+        - packages
+        - linux
+        - linuxrpm
+
+
+#Install docker
+    - name: "Zeek Install: Install docker on debian-based distributions."
+      block:
+        - name: "Zeek Install: Uninstall unofficial docker packages on debian-based distributions."
+          apt:
+            name:
+              - docker-client
+              - docker-client-latest
+              - docker-common
+              - docker-compose
+              - docker-compose-v2
+              - docker-doc
+              - docker-engine
+              - docker-latest
+              - docker-latest-logrotate
+              - docker-logrotate
+              - docker.io
+              - podman-docker
+            state: absent
+            update_cache: true
+            cache_valid_time: 3600
+          tags:
+            - docker
+            - linux
+            - linuxdeb
+
+        - name: "Zeek Install: Install docker-ce on debian-based distributions."
+          apt:
+            name:
+              - docker-ce
+              - docker-ce-cli
+              - docker-compose-plugin
+              - containerd.io
+            state: latest
+            update_cache: true
+            cache_valid_time: 3600
+          tags:
+            - docker
+            - linux
+            - linuxdeb
+
+        - name: "Zeek Install: Install docker modules for Python on deb-based distributions."
+          apt:
+            name:
+              - python3-docker
+              - python3-requests								#We'll have to see if debian/ubuntu can work with the stock (2.28.1 in debian 12.05 / 2.31.0 in ubuntu 24.04)
+          tags:
+            - docker
+            - linux
+            - linuxdeb
+      when: ( ansible_distribution == 'Debian' or ansible_distribution == 'Kali' or ansible_distribution == 'Pop!_OS' or ansible_distribution == 'Ubuntu' or ansible_distribution == 'Zorin OS' )
+
+
+    - name: "Zeek Install: Install docker on rpm-based distributions."
+      block:
+        - name: "Zeek Install: Uninstall unofficial docker packages on rpm-based distributions."
+          yum:
+            name:
+              - docker-client
+              - docker-client-latest
+              - docker-common
+              - docker-compose
+              - docker-compose-v2
+              - docker-doc
+              - docker-engine-selinux
+              - docker-engine
+              - docker-latest
+              - docker-latest-logrotate
+              - docker-logrotate
+              - docker-selinux
+              - docker.io
+              - docker
+              - podman-docker
+              - podman
+              - runc
+            state: absent
+            update_cache: true
+          tags:
+            - docker
+            - linux
+            - linuxrpm
+
+        - name: "Zeek Install: Install docker-ce on rpm-based distributions."
+          yum:
+            name:
+              - docker-ce
+              - docker-ce-cli
+              - docker-buildx-plugin
+              - docker-compose-plugin
+              - containerd.io
+            state: latest
+            update_cache: true
+          tags:
+            - docker
+            - linux
+            - linuxrpm
+      when: ( ansible_distribution == 'AlmaLinux' or ansible_distribution == 'CentOS' or ansible_distribution == 'Fedora' or ansible_distribution == 'OracleLinux' or ansible_distribution == 'RedHat' or ansible_distribution == 'Rocky' )
+      #Reminder that RedHat/RHEL 9 is broken as of 20240618
+
+
+    - name: "Zeek Install: replace python3-requests with a new version installed by pip."
+      block:
+        - name: "Zeek Install: Uninstall unofficial docker packages on rpm-based distributions."
+          yum:
+            name:
+              - python3-requests								#As of 20240618, issue with requests code: "Error connecting: Error while fetching server API version: Not supported URL scheme http+docker".  Installing requests with pip appears to install a newer version that handles the issue.
+            state: absent
+            update_cache: true
+          tags:
+            - docker
+            - linux
+            - linuxrpm
+
+        - name: "Zeek Install: Install docker modules for Python on rpm-based distributions."
+          pip:
+            name:
+              - docker
+              - requests
+          tags:
+            - docker
+            - linux
+            - linuxrpm
+      when: ( ansible_distribution == 'AlmaLinux' or ansible_distribution == 'CentOS' or ansible_distribution == 'Fedora' or ansible_distribution == 'RedHat' or ansible_distribution == 'Rocky' )
+      #OracleLinux and SecurityOnion don't include pip so we can't do these steps there.
+
+
+    - name: "Zeek Install: Start and enable docker in systemd."
+      systemd:
+        name: docker
+        state: started
+        enabled: yes
+      when: ( ansible_distribution != 'OracleLinux' )
+      tags:
+        - docker
+        - linux
+        - linuxdeb
+        - linuxrpm
+      #It appears the "docker modules for python on rpm-based linux" is needed to use the ansible "systemd" module, so we can't use that module on OracleLinux...
+
+      #...so we fall back on starting and enabling it on OracleLinux by hand.
+    - name: "Zeek Install: Start and enable docker in systemd on OracleLinux."
+      shell: systemctl enable docker.service ; systemctl start docker.service
+      when: ( ansible_distribution == 'OracleLinux' )
+      tags:
+        - docker
+        - linux
+        - linuxrpm
+
+    - name: "Zeek Install: Transfer docker-compose script to target system for backwards compatibility."
+      copy:
+        src: docker-compose
+        dest: /usr/local/bin/docker-compose
+        owner: root
+        group: root
+        mode: 0755
+      tags:
+        - docker
+        - zeek
+        - linux
+        - linuxdeb
+        - linuxrpm
+
+#Make directories
+    - name: "Zeek Install: Create zeek directories."
+      ansible.builtin.file:
+        path: "{{  item  }}"
+        state: directory
+        owner: root
+        group: root
+        mode: 0755
+      loop:
+        - /opt/zeek/
+        - /opt/zeek/etc/
+        - /opt/zeek/logs/
+        - /opt/zeek/logs/stats/
+        - /opt/zeek/manual-logs/
+        - /opt/zeek/share/
+        - /opt/zeek/share/zeek/
+        - /opt/zeek/share/zeek/site/
+        - /opt/zeek/share/zeek/site/autoload/
+        - /opt/zeek/spool/
+        - /opt/zeek/spool/installed-scripts-do-not-touch/
+        - /opt/zeek/spool/manager/
+        - /opt/zeek/spool/proxy-1/
+        - /opt/zeek/spool/tmp/
+      tags:
+        - docker
+        - zeek
+        - linux
+        - linuxdeb
+        - linuxrpm
+
+#Install Zeek
+    #Following pulls right from dockerhub.  We may not be able to do this if the system is airgapped
+    #- name: "Zeek Install: Install {{  zeek_container_image  }} docker image."
+    #  block:
+    - name: "Pull from dockerhub container repo"
+      community.docker.docker_image:
+        name: "{{  zeek_container_image  }}"
+        source: pull
+        force_source: true
+    #  rescue:
+    #    - name: "Zeek Install: Transfer Zeek container image to target system"
+    #      copy:
+    #        src: "zeek-{{  zeek_version  }}-image.tar"
+    #        dest: /opt/zeek
+    #        owner: root
+    #        group: root
+    #        mode: 0644
+    #    - name: "Install Zeek container image from file"
+    #      community.docker.docker_image_load:
+    #        path: "/opt/zeek/zeek-{{  zeek_version  }}-image.tar"
+    #      register: load_result
+    #      #This final one prints a list of the loaded images if we use the above 2 stanzas to load from a file.
+    #    - name: "Zeek Install: Print loaded image names."
+    #      ansible.builtin.debug:
+    #        msg: "Loaded the following images: {{  load_result.image_names | join(', ')  }}"
+      tags:
+        - docker
+        - zeek
+        - linux
+        - linuxdeb
+        - linuxrpm
+
+    - name: "Zeek Install: Transfer zeek shell script to target system."
+      copy:
+        src: ./opt/zeek
+        dest: /usr/local/bin/zeek
+        owner: root
+        group: root
+        mode: 0755
+      tags:
+        - docker
+        - zeek
+        - linux
+        - linuxdeb
+        - linuxrpm
+
+    #- name: "Zeek Install: Transfer zeek install files to /opt/zeek."
+    #  copy:
+    #    src: ./opt/
+    #    dest: /opt/zeek
+    #    owner: root
+    #    group: root
+    #    mode: 0755
+    #  tags:
+    #    - docker
+    #    - zeek
+    #    - linux
+    #    - linuxdeb
+    #    - linuxrpm
+
+    #- name: "Zeek Install: Transfer zeek user files to /opt/zeek/etc."
+    #  copy:
+    #    src: ./etc/
+    #    dest: /opt/zeek/etc
+    #    owner: root
+    #    group: root
+    #    mode: 0755
+    #  tags:
+    #    - docker
+    #    - zeek
+    #    - linux
+    #    - linuxdeb
+    #    - linuxrpm
+
+#Late tasks, including rebooting
+    - name: "Zeek Install: Check if reboot required on rpm-based systems."
+      command: needs-restarting -r
+      register: reboot_result
+      ignore_errors: true
+      when: ( ansible_distribution == 'AlmaLinux' or ansible_distribution == 'CentOS' or ansible_distribution == 'Fedora' or ansible_distribution == 'OracleLinux' or ansible_distribution == 'RedHat' or ansible_distribution == 'Rocky' )
+      tags:
+        - packages
+        - linux
+        - linuxrpm
+
+    - name: "Zeek Install: Check if reboot required on Debian/Ubuntu-based systems."
+      register: reboot_required_file
+      stat:
+        path: /var/run/reboot-required
+        get_checksum: no
+      when: ( ansible_distribution == 'Debian' or ansible_distribution == 'Kali' or ansible_distribution == 'Pop!_OS' or ansible_distribution == 'Ubuntu' or ansible_distribution == 'Zorin OS' )
+      tags:
+        - packages
+        - linux
+        - linuxdeb
+
+    - name: "Zeek Install: Rebooting system if needed."
+      reboot:
+        reboot_timeout: 120
+      when: ( ansible_connection != 'local' and ( ( ansible_distribution == 'Debian' or ansible_distribution == 'Kali' or ansible_distribution == 'Pop!_OS' or ansible_distribution == 'Ubuntu' or ansible_distribution == 'Zorin OS' ) and ( reboot_required_file.stat.exists ) ) or ( ( ansible_distribution == 'AlmaLinux' or ansible_distribution == 'CentOS' or ansible_distribution == 'Fedora' or ansible_distribution == 'OracleLinux' or ansible_distribution == 'RedHat' or ansible_distribution == 'Rocky' ) and ( reboot_result.rc == 1 ) ) )
+      register: reboot_status
+      async: 1
+      poll: 0
+      ignore_errors: True		#If unable to reboot (as ansible refuses to do if installing to localhost) we leave the error at the end of the output but don't treat it as a failure.
+      tags:
+        - packages
+        - linux
+        - linuxdeb
+        - linuxrpm


### PR DESCRIPTION
Request from Chris to install docker-zeek by default when installing rita.  This PR does that by updating rita.sh to allow a command line param of --disable-zeek (zeek is installed by default), and adding an install_zeek.yml playbook for ansible.  This has not been tested yet, here for discussion and may need Naomi's help to integrate it with the other build files.  In particular, we do not yet have the "zeek" shell script in ansible's file collection.