### PR TITLE
Fix spagoop analysis failure due to missing 'tld' column in LEFT JOIN with exploded_dns

### DIFF
--- a/analysis/spagooper.go
+++ b/analysis/spagooper.go
@@ -676,9 +676,16 @@ func (analyzer *Analyzer) ScoopDNS(ctx context.Context, bars *tea.Program) error
 		-- keep tlds which had zero non-dns-server ips in direct connections
 		),
 		historical AS (
-			SELECT min(first_seen) AS first_seen, cutToFirstSignificantSubdomain(fqdn) as tld 
-			FROM metadatabase.historical_first_seen
-			LEFT JOIN exploded_dns USING tld
+			SELECT
+				min(first_seen) AS first_seen,
+    				tld
+			FROM (
+   				SELECT
+       					first_seen,
+	    				cutToFirstSignificantSubdomain(fqdn) AS tld
+	 			FROM metadatabase.historical_first_seen
+     			) AS historical
+			LEFT JOIN zeeklogs.exploded_dns USING (tld)
 			GROUP BY tld
 		),
 		totaled_exploded AS (


### PR DESCRIPTION
Keep getting the error below, this break all analysis. Perhaps the query below fixes this:

2025-06-16T14:08:07Z ERR could not perform uconn spagoop error="could not retrieve unique exploded domains for analysis: code: 47, message: JOIN  LEFT JOIN ... USING (tld) using identifier 'tld' cannot be resolved from left table expression. In scope historical AS (SELECT min(first_seen) AS first_seen, cutToFirstSignificantSubdomain(fqdn) AS tld FROM metadatabase.historical_first_seen LEFT JOIN exploded_dns USING (tld) GROUP BY tld)"