### PR TITLE
Tweak ZoneTransferConnectivityErrors Struct Field Types

### DIFF
--- a/zonetransfer/zonetransfer.go
+++ b/zonetransfer/zonetransfer.go
@@ -40,10 +40,10 @@ type PerformedZoneTransfer struct {
 }
 
 type ZoneTransferConnectivityErrors struct {
-	NameServerUnreachableUDPError error `json:"name_server_unreachable_udp"`
-	NameServerUnreachableTCPError error `json:"name_server_unreachable_tcp"`
-	UDPQueryFailedError           error `json:"udp_query_failed"`
-	AXFRFailedError               error `json:"axfr_failed"`
+	NameServerUnreachableUDPError string `json:"name_server_unreachable_udp"`
+	NameServerUnreachableTCPError string `json:"name_server_unreachable_tcp"`
+	UDPQueryFailedError           string `json:"udp_query_failed"`
+	AXFRFailedError               string `json:"axfr_failed"`
 }
 
 type ZoneTransfer struct {
@@ -250,12 +250,12 @@ func (zt *ZoneTransfer) TestConnectivity() ZoneTransferConnectivityErrors {
 	zlog := logger.GetLogger()
 
 	if err := zt.TestNetConnectivity("udp"); err != nil {
-		result.NameServerUnreachableUDPError = err
+		result.NameServerUnreachableUDPError = err.Error()
 		zlog.Error().Err(err).Str("name_server", zt.nameServer).Msg("name server unreachable via UDP")
 	}
 
 	if err := zt.TestNetConnectivity("tcp"); err != nil {
-		result.NameServerUnreachableTCPError = err
+		result.NameServerUnreachableTCPError = err.Error()
 		zlog.Error().Err(err).Str("name_server", zt.nameServer).Msg("name server unreachable via TCP")
 	}
 
@@ -266,7 +266,7 @@ func (zt *ZoneTransfer) TestConnectivity() ZoneTransferConnectivityErrors {
 
 	_, _, err := client.Exchange(msg, zt.nameServer)
 	if err != nil {
-		result.UDPQueryFailedError = err
+		result.UDPQueryFailedError = err.Error()
 		zlog.Error().Err(err).Str("name_server", zt.nameServer).Str("domain_name", zt.domainName).Msg("failed to perform SOA query over UDP")
 	}
 
@@ -276,7 +276,7 @@ func (zt *ZoneTransfer) TestConnectivity() ZoneTransferConnectivityErrors {
 
 	_, err = t.In(m, zt.nameServer)
 	if err != nil {
-		result.AXFRFailedError = err
+		result.AXFRFailedError = err.Error()
 		zlog.Error().Err(err).Str("name_server", zt.nameServer).Str("domain_name", zt.domainName).Msg("failed to perform AXFR zone transfer")
 	}
 


### PR DESCRIPTION
Tweaked the `ZoneTransferConnectivityErrors` struct to use `string`-typed fields instead of `error`.

With how we're performing zone transfers, the error can be different types of errors, specifically `&net.OpError` and `&dns.Error` (and possibly others). Because `&dns.Error` does not export its `err` struct field, it cannot be directly marshalled into JSON in the AC-Hunter middleware. It also doesn't have the other fields that `&net.OpError` has, meaning that trying to include the different error types in a JSON response would be a pain to handle in the AC-Hunter frontend.

Since Golang errors have to satisfy the `error` interface, we have a pretty good guarantee that a reasonable string form of a given error will be available, so this should be a good change if we want to display a human-accessible error to users.