### PR TITLE
Temporarily Disable RITA/Zeek Log Transport

### DIFF
--- a/installer/install_scripts/install_pre.yml
+++ b/installer/install_scripts/install_pre.yml
@@ -470,20 +470,21 @@
         - linuxdeb
         - linuxrpm
 
-    #This keypair will be used for all transfers between all zeek sensors and all achunter systems.
-    #Note that if there's an existing key it will not be overwritten. Keypair will be placed in the playbook directory.
-    #Note: formerly used {{ playbook_dir }}
-    - name: "RITA Pre: Generate ssh keypair for log transfers"
-      local_action:
-        module: "user"
-        name: "{{ lookup('env','USER') }}"
-        generate_ssh_key: true
-        ssh_key_type: "rsa"
-        ssh_key_bits: 4096
-        ssh_key_file: "{{ lookup('env', 'PWD') }}/id_rsa_dataimport"
-      # when: ansible_connection != "local"
-      tags:
-        - docker
-        - linux
-        - linuxdeb
-        - linuxrpm
+    # TODO: Fix and add this back in after RITA#65 is done
+    # #This keypair will be used for all transfers between all zeek sensors and all achunter systems.
+    # #Note that if there's an existing key it will not be overwritten. Keypair will be placed in the playbook directory.
+    # #Note: formerly used {{ playbook_dir }}
+    # - name: "RITA Pre: Generate ssh keypair for log transfers"
+    #   local_action:
+    #     module: "user"
+    #     name: "{{ lookup('env','USER') }}"
+    #     generate_ssh_key: true
+    #     ssh_key_type: "rsa"
+    #     ssh_key_bits: 4096
+    #     ssh_key_file: "{{ lookup('env', 'PWD') }}/id_rsa_dataimport"
+    #   # when: ansible_connection != "local"
+    #   tags:
+    #     - docker
+    #     - linux
+    #     - linuxdeb
+    #     - linuxrpm

--- a/installer/install_scripts/install_rita.sh
+++ b/installer/install_scripts/install_rita.sh
@@ -50,12 +50,11 @@ else
 	./scripts/sshprep "$install_target"
 	status "If asked for a 'BECOME password', that is your non-root sudo password on $install_target ."
 	if [ "$_INSTALL_ZEEK" = 'true' ]; then
-		status "Creating Zeek log transport Cron file"
-		rm -f zeek_log_transport.cron ; touch zeek_log_transport.cron
-		for one_sys in $achunter_dests ; do
-			#NON_ROOT_ACCOUNT_NAME will be replaced after being placed on the target system (by an ansible recipe in install_zeek.yml
-			echo "5 * * * * NON_ROOT_ACCOUNT_NAME /usr/local/bin/zeek_log_transport.sh --dest $one_sys" >>zeek_log_transport.cron
-		done
+		# TODO: fix and re-implement cron setup after RITA#65 is resolved
+		# status "Creating Zeek log transport Cron file"
+		# rm -f zeek_log_transport.cron ; touch zeek_log_transport.cron
+		# #NON_ROOT_ACCOUNT_NAME will be replaced after being placed on the target system (by an ansible recipe in install_zeek.yml
+		# echo "5 * * * * NON_ROOT_ACCOUNT_NAME /usr/local/bin/zeek_log_transport.sh --dest $install_target" >>zeek_log_transport.cron
 
 		ansible-playbook -K -i "${install_target}," -e "install_hosts=${install_target}," install_pre.yml install_rita.yml install_zeek.yml install_post.yml
 	else

--- a/installer/install_scripts/install_zeek.yml
+++ b/installer/install_scripts/install_zeek.yml
@@ -26,7 +26,7 @@
     #Make directories
     - name: "Zeek Install: Create zeek directories."
       ansible.builtin.file:
-        path: "{{  item  }}"
+        path: "{{ item }}"
         state: directory
         owner: root
         group: root
@@ -81,51 +81,54 @@
         - linuxdeb
         - linuxrpm
 
-    - name: "Zeek Install: Transfer zeek_log_transport.sh shell script to target system."
-      copy:
-        src: ./opt/zeek_log_transport.sh
-        dest: /usr/local/bin/zeek_log_transport.sh
-        owner: root
-        group: root
-        mode: 0755
-      when: ansible_connection != "local"
-      tags:
-        - docker
-        - zeek
-        - linux
-        - linuxdeb
-        - linuxrpm
+    # TODO: Fix and add this back in after RITA#65 is done
+    # - name: "Zeek Install: Transfer zeek_log_transport.sh shell script to target system."
+    #   copy:
+    #     src: ./opt/zeek_log_transport.sh
+    #     dest: /usr/local/bin/zeek_log_transport.sh
+    #     owner: root
+    #     group: root
+    #     mode: 0755
+    #   when: ansible_connection != "local"
+    #   tags:
+    #     - docker
+    #     - zeek
+    #     - linux
+    #     - linuxdeb
+    #     - linuxrpm
 
-    - name: "Zeek Install: Transfer zeek_log_transport.cron to target system."
-      copy:
-        src: "{{ lookup('env', 'PWD') }}/zeek_log_transport.cron"
-        dest: /etc/cron.d/zeek_log_transport
-        owner: root
-        group: root
-        mode: 0644
-      when: ansible_connection != "local"
-      tags:
-        - docker
-        - zeek
-        - linux
-        - linuxdeb
-        - linuxrpm
+    # TODO: Fix and add this back in after RITA#65 is done
+    # - name: "Zeek Install: Transfer zeek_log_transport.cron to target system."
+    #   copy:
+    #     src: "{{ lookup('env', 'PWD') }}/zeek_log_transport.cron"
+    #     dest: /etc/cron.d/zeek_log_transport
+    #     owner: root
+    #     group: root
+    #     mode: 0644
+    #   when: ansible_connection != "local"
+    #   tags:
+    #     - docker
+    #     - zeek
+    #     - linux
+    #     - linuxdeb
+    #     - linuxrpm
 
-    - name: "Zeek Install: Place name of remote user in zeek_log_transport cron file"
-      ansible.builtin.replace:
-        path: /etc/cron.d/zeek_log_transport
-        regexp: "^(.*)NON_ROOT_ACCOUNT_NAME(.*)$"
-        replace: '\1{{ lookup("env", "USER") }}\2'
-        mode: 0644
-        owner: root
-        group: root
-      when: ansible_connection != "local"
-      tags:
-        - docker
-        - zeek
-        - linux
-        - linuxdeb
-        - linuxrpm
+    # TODO: Fix and add this back in after RITA#65 is done
+    # - name: "Zeek Install: Place name of remote user in zeek_log_transport cron file"
+    #   ansible.builtin.replace:
+    #     path: /etc/cron.d/zeek_log_transport
+    #     regexp: "^(.*)NON_ROOT_ACCOUNT_NAME(.*)$"
+    #     replace: '\1{{ lookup("env", "USER") }}\2'
+    #     mode: 0644
+    #     owner: root
+    #     group: root
+    #   when: ansible_connection != "local"
+    #   tags:
+    #     - docker
+    #     - zeek
+    #     - linux
+    #     - linuxdeb
+    #     - linuxrpm
 
     - name: "Zeek Install: check whether node.cfg exists to decide if this is the first time running zeek."
       stat:
@@ -155,64 +158,68 @@
         - linuxdeb
         - linuxrpm
 
-    - name: "Zeek Install: Create .ssh directory."
-      ansible.builtin.file:
-        path: "{{ lookup('env', 'HOME') }}/.ssh"
-        state: directory
-        owner: "{{ lookup('env', 'USER') }}"
-        mode: 0700
-      when: ansible_connection != "local"
-      tags:
-        - docker
-        - zeek
-        - linux
-        - linuxdeb
-        - linuxrpm
+    # TODO: Fix and add this back in after RITA#65 is done
+    # - name: "Zeek Install: Create .ssh directory."
+    #   ansible.builtin.file:
+    #     path: "{{ lookup('env', 'HOME') }}/.ssh"
+    #     state: directory
+    #     owner: "{{ lookup('env', 'USER') }}"
+    #     mode: 0700
+    #   when: ansible_connection != "local"
+    #   tags:
+    #     - docker
+    #     - zeek
+    #     - linux
+    #     - linuxdeb
+    #     - linuxrpm
 
-    - name: "Zeek Install: Transfer dataimport private key to .ssh"
-      copy:
-        src: "{{ lookup('env', 'PWD') }}/id_rsa_dataimport"
-        dest: "{{ lookup('env', 'HOME') }}/.ssh/"
-        owner: "{{ lookup('env', 'USER') }}"
-        mode: 0600
-        backup: true
-      when: ansible_connection != "local"
-      tags:
-        - docker
-        - zeek
-        - linux
-        - linuxdeb
-        - linuxrpm
+    # TODO: Fix and add this back in after RITA#65 is done
+    # - name: "Zeek Install: Transfer dataimport private key to .ssh"
+    #   copy:
+    #     src: "{{ lookup('env', 'PWD') }}/id_rsa_dataimport"
+    #     dest: "{{ lookup('env', 'HOME') }}/.ssh/"
+    #     owner: "{{ lookup('env', 'USER') }}"
+    #     mode: 0600
+    #     backup: true
+    #   when: ansible_connection != "local"
+    #   tags:
+    #     - docker
+    #     - zeek
+    #     - linux
+    #     - linuxdeb
+    #     - linuxrpm
 
-    - name: "Zeek Install: Transfer dataimport public key to .ssh"
-      copy:
-        src: "{{ lookup('env', 'PWD') }}/id_rsa_dataimport.pub"
-        dest: "{{ lookup('env', 'HOME') }}/.ssh/"
-        owner: "{{ lookup('env', 'USER') }}"
-        mode: 0644
-        backup: true
-      when: ansible_connection != "local"
-      tags:
-        - docker
-        - zeek
-        - linux
-        - linuxdeb
-        - linuxrpm
+    # TODO: Fix and add this back in after RITA#65 is done
+    # - name: "Zeek Install: Transfer dataimport public key to .ssh"
+    #   copy:
+    #     src: "{{ lookup('env', 'PWD') }}/id_rsa_dataimport.pub"
+    #     dest: "{{ lookup('env', 'HOME') }}/.ssh/"
+    #     owner: "{{ lookup('env', 'USER') }}"
+    #     mode: 0644
+    #     backup: true
+    #   when: ansible_connection != "local"
+    #   tags:
+    #     - docker
+    #     - zeek
+    #     - linux
+    #     - linuxdeb
+    #     - linuxrpm
 
-    - name: "Zeek Install: Update known_hosts with entries from known_hosts on this system"
-      ansible.builtin.blockinfile:
-        block: "{{ lookup('ansible.builtin.file', '{{ local_known_hosts }}') }}"
-        path: "{{ lookup('env', 'HOME') }}/.ssh/known_hosts"
-        marker: "# {mark} ANSIBLE MANAGED BLOCK APPENDED DURING ZEEK INSTALL"
-        owner: "{{ lookup('env', 'USER') }}"
-        backup: true
-        create: true
-        mode: 0644
-      when: ansible_connection != "local"
-      tags:
-        - docker
-        - zeek
-        - linux
-        - linuxdeb
-        - linuxrpm
+    # TODO: Fix and add this back in after RITA#65 is done
+    # - name: "Zeek Install: Update known_hosts with entries from known_hosts on this system"
+    #   ansible.builtin.blockinfile:
+    #     block: "{{ lookup('ansible.builtin.file', '{{ local_known_hosts }}') }}"
+    #     path: "{{ lookup('env', 'HOME') }}/.ssh/known_hosts"
+    #     marker: "# {mark} ANSIBLE MANAGED BLOCK APPENDED DURING ZEEK INSTALL"
+    #     owner: "{{ lookup('env', 'USER') }}"
+    #     backup: true
+    #     create: true
+    #     mode: 0644
+    #   when: ansible_connection != "local"
+    #   tags:
+    #     - docker
+    #     - zeek
+    #     - linux
+    #     - linuxdeb
+    #     - linuxrpm
 #The install_post.yml script should be run next


### PR DESCRIPTION
Temporarily disables anything in RITA/Zeek installer related to log transport automation.

All log transport tasks will have to be handled exclusively in AC-Hunter installer until #65 is fixed.