### PR TITLE
Silence User Input for Repository and Package Installation

### DIFF
--- a/installer/install_scripts/ansible-installer.sh
+++ b/installer/install_scripts/ansible-installer.sh
@@ -78,38 +78,38 @@ enable_repositories() {
 			$SUDO dnf install -y epel-release
 			;;
 		centos/7)
-			$SUDO yum install epel-release
+			$SUDO yum install -y epel-release
 			;;
 		centos/8)
 			$SUDO dnf config-manager --set-enabled powertools
-			$SUDO dnf install epel-release epel-next-release
+			$SUDO dnf install -y epel-release epel-next-release
 			;;
 		centos/9)
 			$SUDO dnf config-manager --set-enabled crb
-			$SUDO dnf install epel-release epel-next-release
+			$SUDO dnf install -y epel-release epel-next-release
 			;;
 		debian/12|zorin/16)
 			:	#Does not appear that any extra repositories are needed
 			;;
 		kali/*)
 			$SUDO apt update
-			$SUDO apt install software-properties-common || sudo apt install python-software-properties
-			$SUDO add-apt-repository --yes --update ppa:ansible/ansible
+			$SUDO apt install -y software-properties-common || $SUDO apt install -y python-software-properties
+			$SUDO add-apt-repository -y --update ppa:ansible/ansible
 			;;
 		ol/*)											#Oracle linux, which is also the base for security onion 2470
 			:
 			;;
 		rhel/7)
 			$SUDO subscription-manager repos --enable rhel-*-optional-rpms --enable rhel-*-extras-rpms --enable rhel-ha-for-rhel-*-server-rpms
-			$SUDO yum install https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+			$SUDO yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
 			;;
 		rhel/8)
 			$SUDO subscription-manager repos --enable codeready-builder-for-rhel-8-$(arch)-rpms
-			$SUDO dnf install https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
+			$SUDO dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
 			;;
 		rhel/9*)
 			$SUDO subscription-manager repos --enable codeready-builder-for-rhel-9-$(arch)-rpms
-			$SUDO dnf install https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm
+			$SUDO dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm
 			;;
 		fedora/*)
 			:										#It does not appear that fedora needs any extra repositories
@@ -119,8 +119,8 @@ enable_repositories() {
 			;;
 		ubuntu/*)
 			$SUDO apt update
-			$SUDO apt install software-properties-common || sudo apt install python-software-properties
-			$SUDO add-apt-repository --yes --update ppa:ansible/ansible
+			$SUDO apt install -y software-properties-common || $SUDO apt install -y python-software-properties
+			$SUDO add-apt-repository -y --update ppa:ansible/ansible
 			;;
 		*)
 			fail "unknown OS $ID/$VERSION_ID"
@@ -136,7 +136,7 @@ patch_system() {
 	status "Patching system"		#================
 	if [ -x /usr/bin/apt-get -a -x /usr/bin/dpkg-query ]; then
 		if [ -s /etc/os-release ] && egrep -iq '(^ID=ubuntu|^ID=pop|^ID=Zorin OS)' /etc/os-release ; then	#The "universe" repository is only available on Ubuntu (and, in theory, popos and Zorin)  Kali DOES NOT have universe
-			while ! $SUDO add-apt-repository --yes universe ; do
+			while ! $SUDO add-apt-repository -y universe ; do
 				echo "Error subscribing to universe repository, perhaps because a system update is running; will wait 60 seconds and try again." >&2
 				sleep 60
 			done
@@ -301,9 +301,9 @@ if ! echo "$PATH" | grep -q '/usr/local/bin' ; then
 	export PATH="$PATH:/usr/local/bin/"
 	#...and for future logins
 	if [ -s /etc/environment ]; then
-		echo 'export PATH="$PATH:/usr/local/bin/"' | sudo tee -a /etc/environment >/dev/null
+		echo 'export PATH="$PATH:/usr/local/bin/"' | $SUDO tee -a /etc/environment >/dev/null
 	elif [ -s /etc/profile ]; then
-		echo 'export PATH="$PATH:/usr/local/bin/"' | sudo tee -a /etc/profile >/dev/null
+		echo 'export PATH="$PATH:/usr/local/bin/"' | $SUDO tee -a /etc/profile >/dev/null
 	else
 		echo "Unable to add /usr/local/bin/ to path." >&2
 	fi


### PR DESCRIPTION
Closes #67.

`apt` and `dnf`/`yum` use different long names for the `-y` flag, but `-y` seems more ubiquitous so I changed over to using that for cleanliness.

Also caught some straggling `sudo` usage instead of `$SUDO`, so I smoothed those out as well.

Tested on CentOS Stream 9, Rocky 9, and Ubuntu 24.04.