### PR TITLE
feat: add threat intel feeds volume to docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,7 @@ services:
     volumes:
       - ${CONFIG_FILE:-/etc/rita/config.hjson}:/config.hjson
       - ${CONFIG_DIR:-/etc/rita}/http_extensions_list.csv:/deployment/http_extensions_list.csv
+      - ${CONFIG_DIR:-/etc/rita}/threat_intel_feeds:/deployment/threat_intel_feeds
       - .env:/.env
       # - ${LOGS:?"You must provide a directory for logs to be read from"}:/logs:ro
     links:


### PR DESCRIPTION
Add volume mapping for threat intelligence feeds directory in docker-compose.yml to allow RITA to access external threat intel data. This was missing from the compose file, leading to the error `Field validation for 'ThreatIntelCustomFeedsDirectory' failed on the 'dir' tag`

Fix #70. @william-stearns 