### PR TITLE
Resolve Installer Side Effects and Formalize RHEL Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,18 +38,15 @@ The framework ingests [Zeek Logs](https://www.zeek.org/) in TSV or JSON format, 
 
 
 ### Supported Platforms
-- ✅: Official Support
-- ⚠️: Unofficial Support
-- ❌: Unsupported
 
-| OS              | Versions | Platform | Status | 
-| :---------------- | :------ | :---- | :----: | 
-| CentOS         | `9 Stream` | `amd64` | ✅ |
-| Rocky         | `9` | `amd64` | ✅ |
-| Ubuntu        |   `24.04`   | `amd64`| ✅ |
-| Windows        |    | | ❌ |
-<!-- TODO: eventually add support -->
-<!-- | MacOS        |   `Sonoma`   | `intel\|arm` | ✅ | -->
+The following operating systems/versions and CPU architectures are supported:
+
+| OS              | Versions         | Platform |
+| :-------------- | :--------------- | :------- |
+| CentOS          | `9 Stream`       | `amd64`  |
+| Rocky           | `9`              | `amd64`  |
+| RHEL            | `9`              | `amd64`  |
+| Ubuntu          | `22.04`, `24.04` | `amd64`  |
 
 ## Installing Zeek
 If you do not already have Zeek installed, it can be installed from [docker-zeek](https://github.com/activecm/docker-zeek).

--- a/installer/install_scripts/ansible-installer.sh
+++ b/installer/install_scripts/ansible-installer.sh
@@ -99,11 +99,11 @@ enable_repositories() {
 		ol/*)											#Oracle linux, which is also the base for security onion 2470
 			:
 			;;
-		rhel/7)
+		rhel/7*)
 			$SUDO subscription-manager repos --enable rhel-*-optional-rpms --enable rhel-*-extras-rpms --enable rhel-ha-for-rhel-*-server-rpms
 			$SUDO yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
 			;;
-		rhel/8)
+		rhel/8*)
 			$SUDO subscription-manager repos --enable codeready-builder-for-rhel-8-$(arch)-rpms
 			$SUDO dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
 			;;

--- a/installer/install_scripts/install_pre.yml
+++ b/installer/install_scripts/install_pre.yml
@@ -410,31 +410,6 @@
             - linuxrpm
       when: ( ansible_distribution == 'AlmaLinux' or ansible_distribution == 'CentOS' or ansible_distribution == 'Fedora' or ansible_distribution == 'OracleLinux' or ansible_distribution == 'RedHat' or ansible_distribution == 'Rocky' )
 
-    - name: "RITA Pre: replace python3-requests with a new version installed by pip."
-      block:
-        - name: "RITA Pre: Uninstall unofficial docker packages on rpm-based distributions."
-          yum:
-            name:
-              - python3-requests #As of 20240618, issue with requests code: "Error connecting: Error while fetching server API version: Not supported URL scheme http+docker". Installing requests with pip appears to install a newer version that handles the issue.
-            state: absent
-            update_cache: true
-          tags:
-            - docker
-            - linux
-            - linuxrpm
-
-        - name: "RITA Pre: Install docker modules for Python on rpm-based distributions."
-          pip:
-            name:
-              - docker
-              - requests
-          tags:
-            - docker
-            - linux
-            - linuxrpm
-      when: ( ansible_distribution == 'AlmaLinux' or ansible_distribution == 'CentOS' or ansible_distribution == 'Fedora' or ansible_distribution == 'RedHat' or ansible_distribution == 'Rocky' )
-      #OracleLinux and SecurityOnion don't include pip so we can't do these steps there.
-
     - name: "RITA Pre: Start and enable docker in systemd."
       systemd:
         name: docker


### PR DESCRIPTION
Closes #72.

Resolves side effects introduced by attempting to replace `python3-requests` package by removing the offending task. Everything tested fine and I encountered no errors on a laundry list of RHEL flavors and versions.

Also, added RHEL support to the README.