### PR TITLE
Resolve Ansible Reboot Errors

### DIFF
--- a/installer/install_scripts/install_post.yml
+++ b/installer/install_scripts/install_post.yml
@@ -28,7 +28,8 @@
     - name: "RITA Post: Check if reboot required on rpm-based systems."
       command: needs-restarting -r
       register: reboot_result
-      ignore_errors: true
+      ignore_errors: True
+      failed_when: reboot_result.rc is not defined
       when: ansible_distribution == 'AlmaLinux' or ansible_distribution == 'CentOS' or ansible_distribution == 'Fedora' or ansible_distribution == 'OracleLinux' or ansible_distribution == 'RedHat' or ansible_distribution == 'Rocky'
       tags:
         - packages
@@ -40,6 +41,7 @@
       stat:
         path: /var/run/reboot-required
         get_checksum: no
+      ignore_errors: True
       when: ansible_distribution == 'Debian' or ansible_distribution == 'Kali' or ansible_distribution == 'Pop!_OS' or ansible_distribution == 'Ubuntu' or ansible_distribution == 'Zorin OS'
       tags:
         - packages

--- a/installer/install_scripts/install_post.yml
+++ b/installer/install_scripts/install_post.yml
@@ -29,18 +29,18 @@
       command: needs-restarting -r
       register: reboot_result
       ignore_errors: true
-      when: ( ansible_distribution == 'AlmaLinux' or ansible_distribution == 'CentOS' or ansible_distribution == 'Fedora' or ansible_distribution == 'OracleLinux' or ansible_distribution == 'RedHat' or ansible_distribution == 'Rocky' )
+      when: ansible_distribution == 'AlmaLinux' or ansible_distribution == 'CentOS' or ansible_distribution == 'Fedora' or ansible_distribution == 'OracleLinux' or ansible_distribution == 'RedHat' or ansible_distribution == 'Rocky'
       tags:
         - packages
         - linux
         - linuxrpm
 
-    - name: "RITA Post: Check if reboot required on Debian/Ubuntu-based systems."
+    - name: "RITA Post: Check if reboot required on deb-based systems."
       register: reboot_required_file
       stat:
         path: /var/run/reboot-required
         get_checksum: no
-      when: ( ansible_distribution == 'Debian' or ansible_distribution == 'Kali' or ansible_distribution == 'Pop!_OS' or ansible_distribution == 'Ubuntu' or ansible_distribution == 'Zorin OS' )
+      when: ansible_distribution == 'Debian' or ansible_distribution == 'Kali' or ansible_distribution == 'Pop!_OS' or ansible_distribution == 'Ubuntu' or ansible_distribution == 'Zorin OS'
       tags:
         - packages
         - linux
@@ -49,10 +49,10 @@
     - name: "RITA Post: Rebooting system if needed."
       reboot:
         reboot_timeout: 120
-      when: ( ansible_connection != 'local' and ( ( ansible_distribution == 'Debian' or ansible_distribution == 'Kali' or ansible_distribution == 'Pop!_OS' or ansible_distribution == 'Ubuntu' or ansible_distribution == 'Zorin OS' ) and ( reboot_required_file.stat.exists ) ) or ( ( ansible_distribution == 'AlmaLinux' or ansible_distribution == 'CentOS' or ansible_distribution == 'Fedora' or ansible_distribution == 'OracleLinux' or ansible_distribution == 'RedHat' or ansible_distribution == 'Rocky' ) and ( reboot_result.rc == 1 ) ) )
+      when:
+        - ansible_connection != 'local'
+        - (reboot_required_file.stat is defined and reboot_required_file.stat.exists) or (reboot_result.rc is defined and reboot_result.rc == 1)
       register: reboot_status
-      async: 1
-      poll: 0
       ignore_errors: True #If unable to reboot (as ansible refuses to do if installing to localhost) we leave the error at the end of the output but don't treat it as a failure.
       tags:
         - packages


### PR DESCRIPTION
Closes #64.

Makes the following changes:
- Resolves error on Ubuntu caused by using unsupported/removed async attributes in the reboot module
- Uniformly adds `ignore_errors: True` to reboot necessity checking steps to ensure that errors are non-fatal
- Suppresses output of `needs-restarting -r` being treated as errors
- Cleans up conditionals (especially in the reboot block)

I learned that registered variables are still populated even when a given task is skipped, hence why the reboot condition checks for definition of `reboot_required_file.stat` and `reboot_result.rc`, rather than `reboot_required_file` and `reboot_result` respectively.

Tested on:
- Ubuntu
- CentOS Stream
- Rocky
- RHEL