### PR TITLE
Install Ansible with Pipx

### DIFF
--- a/installer/install_scripts/ansible-installer.sh
+++ b/installer/install_scripts/ansible-installer.sh
@@ -219,6 +219,17 @@ install_tool() {
 	fi
 }
 
+install_ansible() {
+	# install pipx package locally
+	python3 -m pip install pipx --user
+
+	# prepend ~/.local/bin to path if not present
+	[[ ":$PATH:" != *":$HOME/.local/bin:"* ]] && PATH="$HOME/.local/bin:${PATH}"
+
+	# install ansible and ansible-core via pipx
+	pipx install ansible ansible-core
+}
+
 echo "ansible_installer version $ansible_installer_version" >&2
 
 #FIXME We no longer need these choices, remove the following block
@@ -281,7 +292,8 @@ else
 	install_tool wget "wget"
 	install_tool curl "curl"
 	install_tool sha256sum "coreutils"
-	install_tool ansible "ansible ansible-core"
+
+	install_ansible
 fi
 
 
@@ -309,9 +321,7 @@ if ! echo "$PATH" | grep -q '/usr/local/bin' ; then
 	fi
 fi
 
-ansible-galaxy collection install community.docker --force
-
-
-
+# install requisite ansible collections
+ansible-galaxy collection install community.general community.docker --force
 
 popd > /dev/null

--- a/installer/install_scripts/ansible-installer.sh
+++ b/installer/install_scripts/ansible-installer.sh
@@ -220,14 +220,21 @@ install_tool() {
 }
 
 install_ansible() {
-	# install pipx package locally
-	python3 -m pip install pipx --user
+	# install pipx package in a Python virtual environment (PEP 668 mitigation)
+	python3 -m venv .ansenv
+	source .ansenv/bin/activate
 
-	# prepend ~/.local/bin to path if not present
-	[[ ":$PATH:" != *":$HOME/.local/bin:"* ]] && PATH="$HOME/.local/bin:${PATH}"
+	python3 -m pip install pipx
+
+	pipx ensurepath --prepend
 
 	# install ansible and ansible-core via pipx
 	pipx install ansible ansible-core
+
+	deactivate
+
+	# prepend ~/.local/bin to path if not present
+	[[ ":$PATH:" != *":$HOME/.local/bin:"* ]] && PATH="$HOME/.local/bin:${PATH}"
 }
 
 echo "ansible_installer version $ansible_installer_version" >&2
@@ -283,6 +290,7 @@ else
 	status "Installing needed tools"		#================
 	install_tool python3 "python3"
 	install_tool pip3 "python3-pip"			#Note, oracle linux does not come with pip at all.  The "python3-pip-wheel" package does not include pip.
+	install_tool venv "python3-venv"
 	python3 -m pip -V ; retcode="$?"
 	if [ "$retcode" != 0 ]; then
 		fail "Unable to run python3's pip, exiting."

--- a/installer/install_scripts/ansible-installer.sh
+++ b/installer/install_scripts/ansible-installer.sh
@@ -229,7 +229,7 @@ install_ansible() {
 	pipx ensurepath --prepend
 
 	# install ansible and ansible-core via pipx
-	pipx install ansible ansible-core
+	pipx install ansible ansible-core==2.15.3
 
 	deactivate
 

--- a/installer/install_scripts/ansible-installer.sh
+++ b/installer/install_scripts/ansible-installer.sh
@@ -229,7 +229,7 @@ install_ansible() {
 	pipx ensurepath --prepend
 
 	# install ansible and ansible-core via pipx
-	pipx install ansible ansible-core==2.15.3
+	pipx install ansible ansible-core==2.15.13 --force
 
 	deactivate
 

--- a/installer/install_scripts/install_rita.sh
+++ b/installer/install_scripts/install_rita.sh
@@ -31,6 +31,9 @@ source ./scripts/helper.sh
 
 ./scripts/ansible-installer.sh
 
+# prepend ~/.local/bin to path if not present
+[[ ":$PATH:" != *":$HOME/.local/bin:"* ]] && PATH="$HOME/.local/bin:${PATH}"
+
 
 status "Installing rita via ansible on $install_target"		#================
 if [ "$install_target" = "localhost" -o "$install_target" = "127.0.0.1" -o "$install_target" = "::1" ]; then


### PR DESCRIPTION
Install Ansible using `pipx` instead of using Linux package managers. Requires `pipx` as an additional dependency.

Resolves a version conflict issue for RPM distributions that occurs when installing to a remote Ubuntu target. `dnf` provides ansible core version 2.14.18, `pipx` provides version 2.15.13, which includes a back-ported patch for this issue.