### PR TITLE
Limits for available CPU cores during importing

### DIFF
--- a/cmd/import.go
+++ b/cmd/import.go
@@ -27,12 +27,6 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
-var (
-	numParsers   = 8 // largest impact
-	numDigesters = 8
-	numWriters   = 12 // 2nd largest impact
-)
-
 // for rolling datasets, limit the logs that are imported to the past 14 (to match the snapshot tables) + 1 (for good luck) days
 const RollingLogDaysToKeep = 15
 
@@ -129,10 +123,13 @@ type ImportResults struct {
 }
 
 func RunImportCmd(startTime time.Time, cfg *config.Config, afs afero.Fs, logDir string, dbName string, rolling bool, rebuild bool) (ImportResults, error) {
-	// set the number of workers based on the number of CPUs
-	numParsers = int(math.Floor(math.Max(4, float64(runtime.NumCPU())/2)))
-	numDigesters = int(math.Floor(math.Max(4, float64(runtime.NumCPU())/2)))
-	numWriters = int(math.Floor(math.Max(4, float64(runtime.NumCPU())/2)))
+	availableCores := GetAvailableCores(runtime.NumCPU())
+	if availableCores > 2 {
+		runtime.GOMAXPROCS(availableCores)
+	}
+
+	// set the number of workers based on the number of available CPUs
+	numParsers, numDigesters, numWriters := SetWorkerCount(availableCores)
 
 	var importResults ImportResults
 	logger := zlog.GetLogger()
@@ -316,6 +313,28 @@ func RunImportCmd(startTime time.Time, cfg *config.Config, afs afero.Fs, logDir 
 	logger.Info().Str("elapsed_time", fmt.Sprintf("%1.1fs", time.Since(startTime).Seconds())).Msg("🎊✨ Finished Import! ✨🎊")
 
 	return importResults, nil
+}
+
+// Get the amount of logical cores available without the program interrupting other system processes.
+// At the time of writing the recommended minimal cpu count is 3 so for systems with less let all be available.
+func GetAvailableCores(coresNum int) int {
+	if coresNum > 2 {
+		if coresNum == 3 {
+			coresNum -= 1
+		} else {
+			coresNum -= 2
+		}
+	}
+
+	return coresNum
+}
+
+func SetWorkerCount(availableCores int) (int, int, int) {
+	numParsers := int(math.Floor(math.Max(1, float64(availableCores)/3)))
+	numDigesters := int(math.Floor(math.Max(1, float64(availableCores)/3)))
+	numWriters := int(math.Floor(math.Max(1, float64(availableCores)/3)))
+
+	return numParsers, numDigesters, numWriters
 }
 
 func ValidateLogDirectory(afs afero.Fs, logDir string) error {

--- a/cmd/import.go
+++ b/cmd/import.go
@@ -318,12 +318,10 @@ func RunImportCmd(startTime time.Time, cfg *config.Config, afs afero.Fs, logDir 
 // Get the amount of logical cores available without the program interrupting other system processes.
 // At the time of writing the recommended minimal cpu count is 3 so for systems with less let all be available.
 func GetAvailableCores(coresNum int) int {
-	if coresNum > 2 {
-		if coresNum == 3 {
-			coresNum -= 1
-		} else {
-			coresNum -= 2
-		}
+	if coresNum == 3 {
+		coresNum--
+	} else if coresNum > 3 {
+		coresNum -= 2
 	}
 
 	return coresNum

--- a/cmd/import_test.go
+++ b/cmd/import_test.go
@@ -51,6 +51,65 @@ NON-ROLLING LOGS
   - 2024-05-02
 */
 
+func (c *CmdTestSuite) TestWorkerCount() {
+	type TestCase struct {
+		name                   string
+		cpuCores               int
+		expectedAvailableCores int
+	}
+
+	testCases := []TestCase{
+		{
+			name:                   "System with 64 cpu cores",
+			cpuCores:               64,
+			expectedAvailableCores: 62,
+		},
+		{
+			name:                   "System with 30 cpu cores",
+			cpuCores:               30,
+			expectedAvailableCores: 28,
+		},
+		{
+			name:                   "System with 15 cpu cores",
+			cpuCores:               15,
+			expectedAvailableCores: 13,
+		},
+		{
+			name:                   "System with 3 cpu cores",
+			cpuCores:               3,
+			expectedAvailableCores: 2,
+		},
+		{
+			name:                   "System with 2 cpu cores",
+			cpuCores:               2,
+			expectedAvailableCores: 2,
+		},
+		{
+			name:                   "System with 1 cpu core",
+			cpuCores:               1,
+			expectedAvailableCores: 1,
+		},
+	}
+
+	for _, tc := range testCases {
+		c.Run(tc.name, func() {
+			t := c.T()
+
+			availableCores := cmd.GetAvailableCores(tc.cpuCores)
+			numParsers, numDigesters, numWriters := cmd.SetWorkerCount(availableCores)
+			workersSum := numParsers + numDigesters + numWriters
+
+			if tc.cpuCores > 3 {
+				require.LessOrEqual(t, workersSum, availableCores, "number of workers should not be larger than the number of available cores")
+			} else {
+				require.Equal(t, 3, workersSum, "number of workers should be equal to: 3")
+			}
+
+			require.Equal(t, tc.expectedAvailableCores, availableCores, "number of available cores should be equal to: %d", tc.expectedAvailableCores)
+		})
+	}
+}
+
 func (c *CmdTestSuite) TestRunImportCmd() {
 	type importDB struct {
 		name           string


### PR DESCRIPTION
Added the following limits for logical CPU cores usage during importing:
- for systems with more than 3 cores: all cores - 2
- with 3 cores:  all cores - 1
- with less than 3 cores: all cores

Also added tests for new functions.