### PR TITLE
potential fix: Send version message to stderr instead of stdout.

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"errors"
 	"fmt"
+	"os"
 
 	"github.com/activecm/rita/v5/config"
 	"github.com/activecm/rita/v5/util"
@@ -59,7 +60,8 @@ func CheckForUpdate(cfg *config.Config) error {
 			return fmt.Errorf("%w: %w", ErrCheckingForUpdate, err)
 		}
 		if newer {
-			fmt.Printf("\n\t✨ A newer version (%s) of RITA is available! https://github.com/activecm/rita/releases ✨\n\n", latestVersion)
+			// Envía el mensaje a stderr para no contaminar la salida de stdout (e.g., CSV)
+			fmt.Fprintf(os.Stderr, "\n\t✨ A newer version (%s) of RITA is available! https://github.com/activecm/rita/releases ✨\n\n", latestVersion)
 		}
 	}
 	return nil


### PR DESCRIPTION
Resolves issue #83, where the message 'A newer version of RITA is available!' was sent to stdout, thereby breaking CSV output and disrupting automated workflows that use Logstash to parse the CSVs.

The message is now sent to stderr using `fmt.Fprintf` to avoid polluting the standard output, which is reserved for important data such as CSVs.

- Changed `fmt.Printf` to `fmt.Fprintf(os.Stderr, ...)`
- Added the `os` package import
- The version message no longer interferes with data output