### PR TITLE
fix: run without TTY by disabling renderer when stderr is not a terminal

### DIFF
--- a/progressbar/progressbar.go
+++ b/progressbar/progressbar.go
@@ -3,6 +3,7 @@ package progressbar
 import (
 	"context"
 	"fmt"
+	"os"
 	"strings"
 	"time"
 
@@ -10,6 +11,7 @@ import (
 	"github.com/charmbracelet/bubbles/spinner"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
+	"github.com/charmbracelet/x/term"
 )
 
 const (
@@ -68,11 +70,16 @@ func NewSpinner(name string, id int) Spinner {
 }
 
 func New(ctx context.Context, bars []*ProgressBar, spinners []Spinner) *tea.Program {
+	opts := []tea.ProgramOption{tea.WithInput(nil)}
+	if !term.IsTerminal(os.Stderr.Fd()) {
+		fmt.Fprintln(os.Stderr, "No terminal detected: progress display disabled, processing continues in the background.")
+		opts = append(opts, tea.WithoutRenderer())
+	}
 	return tea.NewProgram(&ProgressModel{
 		ProgressBars: bars,
 		Spinners:     spinners,
 		ctx:          ctx,
-	}, tea.WithInput(nil))
+	}, opts...)
 }
 
 type tickMsg string

--- a/progressbar/progressbar_test.go
+++ b/progressbar/progressbar_test.go
@@ -1,0 +1,41 @@
+package progressbar_test
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"testing"
+
+	"github.com/activecm/rita/v5/progressbar"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestNew_NoTTY verifies that when stderr is not a terminal (e.g. cron, background job),
+// New prints a human-readable message and the program runs without error instead of
+// crashing with "could not open a new TTY".
+func TestNew_NoTTY(t *testing.T) {
+	// Tests never have a TTY on stderr, so this always exercises the no-TTY path.
+	old := os.Stderr
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	os.Stderr = w
+
+	// Pre-cancel so the bubbletea program exits on its first tick (within 1s).
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	bars := progressbar.New(ctx, nil, nil)
+
+	w.Close()
+	os.Stderr = old
+
+	var buf bytes.Buffer
+	_, err = buf.ReadFrom(r)
+	require.NoError(t, err)
+
+	assert.Contains(t, buf.String(), "No terminal detected", "expected no-TTY message on stderr")
+
+	_, runErr := bars.Run()
+	assert.NoError(t, runErr, "program should exit cleanly without a TTY")
+}


### PR DESCRIPTION
Closes #20

## Summary

When RITA is run in a non-interactive context (cron job, Docker without `--tty`, background process, systemd service), the bubbletea progress renderer panics trying to open a TTY:

```
could not open a new TTY: open /dev/tty: no such device or address
```

**Root cause**: bubbletea unconditionally tries to acquire `/dev/tty` to render its UI. When no controlling terminal exists, that open fails and the program crashes rather than completing the import.

**Fix**: Before creating the bubbletea program, check whether `os.Stderr` is a terminal using `term.IsTerminal(os.Stderr.Fd())` from `github.com/charmbracelet/x/term` (already a transitive dependency — this change adds nothing to `go.mod`). When no terminal is detected:
- Pass `tea.WithoutRenderer()` to the program so bubbletea never attempts to open `/dev/tty`.
- Print a single informational line to stderr so the operator knows why no progress is shown.

`os.Stderr` (fd 2) is checked rather than stdin because bubbletea renders its UI to stderr, which is where the TTY problem surfaces.

## Changes

- `progressbar/progressbar.go`: detect TTY on `os.Stderr` and conditionally pass `tea.WithoutRenderer()`; print message when suppressing the renderer
- `progressbar/progressbar_test.go`: add `TestNew_NoTTY` which redirects stderr to a pipe (simulating a non-TTY environment), runs the program against a pre-cancelled context, and asserts both the informational message and a clean exit

## Test plan

- [x] `TestNew_NoTTY` passes: no-TTY message on stderr, program exits without error
- [x] `go test ./progressbar/...` passes
- [x] `go vet ./...` clean
- [x] `gofmt -s -l .` clean
- [ ] Run `rita import --logs /path/to/logs` inside a Docker container without `--tty` (e.g. `docker run --rm rita import ...`) — import should complete successfully and print the no-TTY message instead of crashing
- [ ] Run `rita import` in a normal terminal — progress bars and spinners should display as before with no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)